### PR TITLE
Make filterBy return a valid load profile

### DIFF
--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -53,7 +53,7 @@ class LoadProfile {
   filterBy(filters: LoadProfileFilterArgs) {
     const filter = new LoadProfileFilter(filters);
 
-    const filteredLoadProfile = this.expanded().filter((detailedLoadProfileHour) => filter.matches(detailedLoadProfileHour));
+    const filteredLoadProfile = this.expanded().map(({load, ...detailedLoadProfileHour}) => filter.matches(detailedLoadProfileHour) ? load : 0);
 
     return new LoadProfile(filteredLoadProfile, {year: this._year});
   }

--- a/src/rateEngine/__tests__/loadProfile.test.ts
+++ b/src/rateEngine/__tests__/loadProfile.test.ts
@@ -47,8 +47,9 @@ describe('Load Profile', () => {
     it('filters by month', () => {
       const filteredByMonth = loadProfile.filterBy({months: [0]});
 
-      expect(filteredByMonth.expanded()).toHaveLength(31 * 24);
-      expect(filteredByMonth.expanded().every(({month}) => month === 0)).toBe(true);
+      expect(filteredByMonth.expanded().map(({load}) => load)).toEqual(
+        (new Array(31*24).fill(1)).concat((new Array(8760 - (31*24))).fill(0))
+      );
     });
   });
 
@@ -79,7 +80,6 @@ describe('Load Profile', () => {
   describe('count', () => {
     it('returns the count', () => {
       expect(loadProfile.count()).toEqual(8760);
-      expect(loadProfile.filterBy({months: [0]}).count()).toEqual(31 * 24);
     });
 
     it('allows a length property too', () => {


### PR DESCRIPTION
Currently, `#filterBy` returns a load profile that only contains the filtered detailed load hours. While this works fine for common analytical operations like `sum`, it's technically an invalid load profile instance and would fail if a user tried to chain another load profile manipulation method off of it (like `aggregate` or `loadShift`). This change makes sure that the result of the filter operation is still a 100% valid load profile.