### PR TITLE
Add loadValues method

### DIFF
--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -50,6 +50,10 @@ class LoadProfile {
     })));
   }
 
+  hourlyLoads(): Array<number> {
+    return this.expanded().map(({load}) => load);
+  }
+
   filterBy(filters: LoadProfileFilterArgs) {
     const filter = new LoadProfileFilter(filters);
 

--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -50,7 +50,7 @@ class LoadProfile {
     })));
   }
 
-  hourlyLoads(): Array<number> {
+  loadValues(): Array<number> {
     return this.expanded().map(({load}) => load);
   }
 

--- a/src/rateEngine/__tests__/loadProfile.test.ts
+++ b/src/rateEngine/__tests__/loadProfile.test.ts
@@ -162,4 +162,10 @@ describe('Load Profile', () => {
       );
     });
   });
+
+  describe('hourlyLoads', () => {
+    it('returns an array of load values', () => {
+      expect(loadProfile.hourlyLoads()).toEqual(getLoadProfileOfOnes());
+    });
+  });
 });

--- a/src/rateEngine/__tests__/loadProfile.test.ts
+++ b/src/rateEngine/__tests__/loadProfile.test.ts
@@ -163,9 +163,9 @@ describe('Load Profile', () => {
     });
   });
 
-  describe('hourlyLoads', () => {
+  describe('loadValues', () => {
     it('returns an array of load values', () => {
-      expect(loadProfile.hourlyLoads()).toEqual(getLoadProfileOfOnes());
+      expect(loadProfile.loadValues()).toEqual(getLoadProfileOfOnes());
     });
   });
 });


### PR DESCRIPTION
This adds a nice shortcut method to get the `raw` load array from a load profile instead of using `loadProfile.expanded().map(({load}) => load)`.

It was originally going to be called `hourlyLoads`, but since we already know that 15 minute load profiles are on the horizon, I changed it to `loadValues` to avoid implying a measurement time.