### PR TITLE
Goal seek improvements

### DIFF
--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -3,7 +3,7 @@ import maxBy from 'lodash/maxBy';
 import { addDecimals } from './utils/decimals';
 import LoadProfileFilter, { LoadProfileFilterArgs } from './LoadProfileFilter';
 import expandedDates, { ExpandedDate } from './utils/expandedDates';
-import LoadProfileScaler from './LoadProfileScaler';
+import LoadProfileScaler, { LoadProfileScalerOptions } from './LoadProfileScaler';
 
 export interface DetailedLoadProfileHour extends ExpandedDate {
   load: number;
@@ -143,8 +143,8 @@ class LoadProfile {
     return this.sum() / (this.count() * this.max());
   }
 
-  scale(): LoadProfileScaler {
-    return new LoadProfileScaler(this);
+  scale(options: LoadProfileScalerOptions): LoadProfileScaler {
+    return new LoadProfileScaler(this, options);
   }
 
   aggregate(otherLoadProfile: LoadProfile): LoadProfile {

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -10,12 +10,12 @@ class LoadProfileScaler {
 
   constructor(loadProfile) {
     this.loadProfile = loadProfile;
-  };
+  }
 
   to(scaler: number): LoadProfile {
     return new LoadProfile(
-      this.loadProfile.expanded().map(loadHour => loadHour.load * scaler),
-      {year: this.loadProfile.year}
+      this.loadProfile.expanded().map((loadHour) => loadHour.load * scaler),
+      { year: this.loadProfile.year },
     );
   }
 
@@ -24,58 +24,61 @@ class LoadProfileScaler {
     return this.to(scaler);
   }
 
-  toAverageMonthlyBill(
-    amount: number,
-    rate: RateInterface
-  ): LoadProfile {
-    // Need this as a percent for better resolution within the algorithm
-    const scalerAsPercent = 100;
-    const fnParams = [scalerAsPercent, rate, this];
+  toAverageMonthlyBill(amount: number, rate: RateInterface): LoadProfile {
+    const magnitude = Math.max(Math.floor(Math.log10(Math.abs(amount))), 0);
+
+    const orderOfMagnitude = 10 ** magnitude;
+    const initialScalerGuess = orderOfMagnitude;
+    const fnParams = [initialScalerGuess, rate, this, magnitude];
 
     try {
-      const finalScalerAsPercent = goalSeek({
+      const finalScaler = goalSeek({
         fn: this.scaledMonthlyCost,
         fnParams,
         percentTolerance: 0.1,
         maxIterations: 1000,
-        maxStep: 50,
+        maxStep: 0.5 * orderOfMagnitude,
         goal: amount,
-        independentVariableIdx: 0
+        independentVariableIdx: 0,
       });
-      return this.to(finalScalerAsPercent / 100);
+
+      const scalerAsDecimal = finalScaler / orderOfMagnitude;
+      return this.to(scalerAsDecimal);
     } catch (e) {
-      throw(e);
+      throw e;
     }
   }
 
   toMonthlyKwh(monthlyKwh: Array<number>): LoadProfile {
     if (monthlyKwh.length !== 12) {
-      throw('monthlyKwh must be an array of 12 numbers');
+      throw 'monthlyKwh must be an array of 12 numbers';
     }
     const scalersByMonth = this.loadProfile.sumByMonth().map((kwh, idx) => {
       return monthlyKwh[idx] / kwh;
     });
-    const scaledLoad = this.loadProfile.expanded().map(loadHour => {
+    const scaledLoad = this.loadProfile.expanded().map((loadHour) => {
       return {
         ...loadHour,
         load: loadHour.load * scalersByMonth[loadHour.month],
       };
     });
-    return new LoadProfile(scaledLoad, {year: this.loadProfile.year});
+    return new LoadProfile(scaledLoad, { year: this.loadProfile.year });
   }
 
   private scaledMonthlyCost(
-    scalerAsPercent: number,
+    scaler: number,
     rate: RateInterface,
     context: LoadProfileScaler,
+    magnitude: number,
   ): number {
-    const scaledLoadProfile = context.to(scalerAsPercent / 100);
+    const scaledLoadProfile = context.to(scaler / 10 ** magnitude);
     const rateCalculator = new RateCalculator({
       ...rate,
       loadProfile: scaledLoadProfile,
     });
+
     return rateCalculator.annualCost() / 12;
-  };
-};
+  }
+}
 
 export default LoadProfileScaler;

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -37,8 +37,8 @@ class LoadProfileScaler {
   toAverageMonthlyBill(amount: number, rate: RateInterface, goalSeekParams: GoalSeekArgs = {}): LoadProfile {
     const magnitude = Math.max(Math.floor(Math.log10(Math.abs(amount))), 0);
 
-    const orderOfMagnitude = 10 ** magnitude;
-    const initialScalerGuess = orderOfMagnitude;
+    const magnitudeScaler = 10 ** magnitude;
+    const initialScalerGuess = magnitudeScaler;
     const fnParams = [initialScalerGuess, rate, this, magnitude];
 
     try {
@@ -47,13 +47,13 @@ class LoadProfileScaler {
         fnParams,
         percentTolerance: 0.1,
         maxIterations: 1000,
-        maxStep: 0.5 * orderOfMagnitude,
+        maxStep: 0.5 * magnitudeScaler,
         goal: amount,
         independentVariableIdx: 0,
         ...goalSeekParams,
       });
 
-      const scalerAsDecimal = finalScaler / orderOfMagnitude;
+      const scalerAsDecimal = finalScaler / magnitudeScaler;
       return this.to(scalerAsDecimal);
     } catch (e) {
       throw e;

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -6,6 +6,10 @@ import RateInterface from './RateInterface';
 // TODO: use proper math for scaling
 // TODO: fix the toAverageMonthlyBill argument... how to properly pass in a rate?
 
+interface GoalSeekArgs {
+  [key: string]: any
+};
+
 export interface LoadProfileScalerOptions {
   debug: boolean;
 }
@@ -30,7 +34,7 @@ class LoadProfileScaler {
     return this.to(scaler);
   }
 
-  toAverageMonthlyBill(amount: number, rate: RateInterface): LoadProfile {
+  toAverageMonthlyBill(amount: number, rate: RateInterface, goalSeekParams: GoalSeekArgs = {}): LoadProfile {
     const magnitude = Math.max(Math.floor(Math.log10(Math.abs(amount))), 0);
 
     const orderOfMagnitude = 10 ** magnitude;
@@ -46,6 +50,7 @@ class LoadProfileScaler {
         maxStep: 0.5 * orderOfMagnitude,
         goal: amount,
         independentVariableIdx: 0,
+        ...goalSeekParams,
       });
 
       const scalerAsDecimal = finalScaler / orderOfMagnitude;

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -5,11 +5,17 @@ import RateInterface from './RateInterface';
 
 // TODO: use proper math for scaling
 // TODO: fix the toAverageMonthlyBill argument... how to properly pass in a rate?
+
+export interface LoadProfileScalerOptions {
+  debug: boolean;
+}
 class LoadProfileScaler {
   loadProfile: LoadProfile;
+  debug: boolean;
 
-  constructor(loadProfile) {
+  constructor(loadProfile, {debug}: LoadProfileScalerOptions = {debug: false}) {
     this.loadProfile = loadProfile;
+    this.debug = debug;
   }
 
   to(scaler: number): LoadProfile {
@@ -77,7 +83,14 @@ class LoadProfileScaler {
       loadProfile: scaledLoadProfile,
     });
 
-    return rateCalculator.annualCost() / 12;
+    const currentMonthlyCost = rateCalculator.annualCost() / 12;
+
+    if (context.debug) {
+      console.log('current scaler is:', scaler);
+      console.log('current monthlyCost is:', currentMonthlyCost);
+    }
+
+    return currentMonthlyCost;
   }
 }
 

--- a/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
@@ -80,4 +80,13 @@ describe('LoadProfileScaler', () => {
       });
     });
   });
+
+  describe('optional debugging', () => {
+    it('prints things to the console', () => {
+      console.log = jest.fn();
+      const scaler = new LoadProfileScaler(initialLoadProfile, { debug: true });
+      const avgMonthlyBill = scaler.toAverageMonthlyBill(100, e1);
+      expect(console.log).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
@@ -4,11 +4,49 @@ import sum from 'lodash/sum';
 import LoadProfile from '../LoadProfile';
 //import goalSeek from 'goal-seek';
 import e1 from '../__mocks__/rates/e-1';
+import RateCalculator, { RateCalculatorInterface } from '../RateCalculator';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 
+const dummyRate = {
+  name: 'some rate',
+  title: 'that will not converge',
+  rateElements: [
+    {
+      rateElementType: 'FixedPerMonth',
+      name: 'Customer Charge',
+      rateComponents: [
+        {
+          charge: 500,
+          name: 'Customer Charge',
+        },
+      ],
+    },
+    {
+      rateElementType: 'MonthlyDemand',
+      name: 'Demand Charge',
+      rateComponents: [
+        {
+          charge: 20,
+          name: 'Demand Charge',
+        },
+      ],
+    },
+    {
+      rateElementType: 'MonthlyEnergy',
+      name: 'Energy Charge',
+      rateComponents: [
+        {
+          charge: 0.18999,
+          name: 'Energy Charge',
+        },
+      ],
+    },
+  ],
+};
+
 describe('LoadProfileScaler', () => {
-  const initialLoadProfile = new LoadProfile(getLoadProfileOfOnes(), {year: 2019});
+  const initialLoadProfile = new LoadProfile(getLoadProfileOfOnes(), { year: 2019 });
   let loadProfileScaler;
 
   beforeEach(() => {
@@ -28,6 +66,17 @@ describe('LoadProfileScaler', () => {
       it('returns a LoadProfile', () => {
         const scaledLoadProfile = loadProfileScaler.toAverageMonthlyBill(100, e1);
         expect(scaledLoadProfile).toBeInstanceOf(LoadProfile);
+      });
+
+      it('converges with a large bill amount', () => {
+        const billAmount = 10000;
+        const scaledLoadProfile = loadProfileScaler.toAverageMonthlyBill(billAmount, dummyRate);
+
+        const rateCalculator = new RateCalculator({
+          ...dummyRate,
+          loadProfile: scaledLoadProfile,
+        } as RateCalculatorInterface);
+        expect(rateCalculator.annualCost() / 12).toBeCloseTo(billAmount);
       });
     });
   });


### PR DESCRIPTION
@jrogers97 discovered that scaling to an average monthly bill would struggle work once the bill amount got to around 10,000.

The reason for that is that the the goal-seek package we use basically does this:

1. Make a guess for a function with a single variable
2. Calculate the error in the result
3. Change the single variable by the amount of the error
4. Guess again

We had the "single variable" hardcoded to `100` (to represent a percent of scaling. However, bill amounts with more than 3 digits, this meant that the amount of the "error" was greater than the entire range that the percent variable could be tweaked. The algorithm would end up wildly overshooting and then undershooting the target value.

This PR scales the "single variable" to make the order of magnitude of the target value, allowing the error in each iteration to adjust the variable in a sensible manner.

This was hard for us to debug, and it is not the first time that we've had trouble figuring out what is going on inside the scaling function. So, this PR also adds some debugging options for the average monthly bill scaling that should help us if we run into an unconverging rate/load profile.