### PR TITLE
Price profile as plain data

### DIFF
--- a/src/rateEngine/RateElement.ts
+++ b/src/rateEngine/RateElement.ts
@@ -18,7 +18,7 @@ export interface RateElementInterface {
   rateComponents?: Array<RateComponentInterface>;
   name: string;
   billingCategory?: BillingCategory;
-  priceProfile?: PriceProfile;
+  priceProfile?: Array<number> | PriceProfile;
 }
 
 export enum RateElementClassification {
@@ -46,7 +46,7 @@ export interface RateElementFilterArgs {
 
 class RateComponentsFactory {
   static make(
-    {rateElementType, rateComponents, name, priceProfile}: RateElementInterface,
+    {rateElementType, rateComponents, name, priceProfile: priceProfileData}: RateElementInterface,
     loadProfile,
     otherRateElements,
   ): Array<RateComponentInterface> {
@@ -65,6 +65,7 @@ class RateComponentsFactory {
             }))
         }).flat();
       case 'HourlyEnergy':
+        const priceProfile = new PriceProfile(priceProfileData, {year: loadProfile.year})
         return priceProfile.expanded().map(({price, hourOfYear}) => ({
           name: `${name} - Hour ${hourOfYear}`,
           charge: price,

--- a/src/rateEngine/__tests__/RateElement.HourlyEnergy.test.ts
+++ b/src/rateEngine/__tests__/RateElement.HourlyEnergy.test.ts
@@ -11,7 +11,7 @@ priceData[ARBITRARY_HOUR_INDEX] = 5;
 const rateElementData = {
   name: 'An hourly energy rate',
   rateElementType: 'HourlyEnergy' as RateElementType,
-  priceProfile: new PriceProfile(priceData, {year: YEAR}),
+  priceProfile: priceData,
 };
 
 const loadProfile = new LoadProfile(Array(8760).fill(2), {year: YEAR})
@@ -26,6 +26,20 @@ describe('RateElement', () => {
     });
 
     it('calculates the monthly costs', () => {
+      expect(rateElement.costs()).toEqual(
+        [10,0,0,0,0,0,0,0,0,0,0,0]
+      )
+    });
+
+    it('works with a PriceProfile for backwards compatibility', () => {
+      const data = {
+        name: 'A rate element with a PriceProfile',
+        rateElementType: 'HourlyEnergy' as RateElementType,
+        priceProfile: new PriceProfile(priceData, {year: YEAR})
+      }
+
+      const element = new RateElement(data, loadProfile);
+
       expect(rateElement.costs()).toEqual(
         [10,0,0,0,0,0,0,0,0,0,0,0]
       )


### PR DESCRIPTION
Allow users to define hourly price data as plain data instead of requiring a constructed object