### PR TITLE
Annual Demand Billing Determinant

### DIFF
--- a/src/rateEngine/BillingDeterminantFactory.ts
+++ b/src/rateEngine/BillingDeterminantFactory.ts
@@ -6,6 +6,7 @@ import BlockedTiersInMonths from './billingDeterminants/BlockedTiersInMonths';
 import { default as EnergyTimeOfUse, EnergyTimeOfUseArgs } from './billingDeterminants/EnergyTimeOfUse';
 import LoadProfile from './LoadProfile';
 import MonthlyDemand from './billingDeterminants/MonthlyDemand';
+import AnnualDemand from './billingDeterminants/AnnualDemand';
 import MonthlyEnergy from './billingDeterminants/MonthlyEnergy';
 import SurchargeAsPercent, { SurchargeAsPercentArgs } from './billingDeterminants/SurchargeAsPercent';
 import HourlyEnergy, { HourlyEnergyArgs } from './billingDeterminants/HourlyEnergy';
@@ -21,6 +22,7 @@ export type RateElementType =
   | 'FixedPerMonth'
   | 'MonthlyEnergy'
   | 'MonthlyDemand'
+  | 'AnnualDemand'
   | 'SurchargeAsPercent'
   | 'HourlyEnergy'
   | 'DemandTimeOfUse'
@@ -53,6 +55,8 @@ class BillingDeterminantFactory {
         return new FixedPerMonth();
       case 'MonthlyDemand':
         return new MonthlyDemand(loadProfile);
+      case 'AnnualDemand':
+        return new AnnualDemand(loadProfile);
       case 'MonthlyEnergy':
         return new MonthlyEnergy(loadProfile);
       case 'SurchargeAsPercent':

--- a/src/rateEngine/billingDeterminants/AnnualDemand.ts
+++ b/src/rateEngine/billingDeterminants/AnnualDemand.ts
@@ -1,0 +1,25 @@
+import BillingDeterminants, { BillingDeterminantsUnits } from './_BillingDeterminants';
+import LoadProfile from '../LoadProfile';
+import { RateElementClassification } from '../RateElement';
+import times from 'lodash/times';
+
+class AnnualDemand extends BillingDeterminants {
+  private _loadProfile: LoadProfile;
+
+  rateElementType = 'Annual Demand';
+  rateElementClassification = RateElementClassification.DEMAND;
+  units = BillingDeterminantsUnits.KW;
+
+  constructor(loadProfile: LoadProfile) {
+    super();
+
+    this._loadProfile = loadProfile;
+  }
+
+  calculate(): Array<number> {
+    const annualMax = this._loadProfile.max();
+    return times(12, () => annualMax);
+  }
+}
+
+export default AnnualDemand;

--- a/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
@@ -1,0 +1,24 @@
+import LoadProfile from '../../LoadProfile';
+import times from 'lodash/times';
+import AnnualDemand from '../AnnualDemand';
+
+const getLoadProfileOfOneThroughTen = () => times(8760, (num) => (num % 10) + 1);
+const getLoadProfileWithOneNonZero = () => times(8760, (i) => (i === 1234 ? 100 : 0));
+
+describe('AnnualDemand', () => {
+  describe('calculate', () => {
+    it('calculates the annual max demand for a load profile of 1 through 10', () => {
+      const loadProfile = new LoadProfile(getLoadProfileOfOneThroughTen(), { year: 2019 });
+      const result = new AnnualDemand(loadProfile).calculate();
+
+      expect(result).toEqual(times(12, () => 10));
+    });
+
+    it('calculates the annual max demand for a load profile with one non-zero value', () => {
+      const loadProfile = new LoadProfile(getLoadProfileWithOneNonZero(), { year: 2019 });
+      const result = new AnnualDemand(loadProfile).calculate();
+
+      expect(result).toEqual(times(12, () => 100));
+    });
+  });
+});


### PR DESCRIPTION
Very simple billing determinant that returns the _annual_ maximum for all 12 months.
Eugene's example: 

A utility with monthly maximums of
`[1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6]`

would output:
`[6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]`