### PR TITLE
Remove moment.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
+        "dayjs": "^1.11.13",
         "goal-seek": "^0.1.4",
         "lodash": "^4.17.21",
-        "moment-timezone": "^0.5.46",
         "typescript": "^5.7"
       },
       "devDependencies": {
@@ -2504,6 +2504,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -5454,27 +5460,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.46",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "keywords": [],
   "author": "",
   "dependencies": {
+    "dayjs": "^1.11.13",
     "goal-seek": "^0.1.4",
     "lodash": "^4.17.21",
-    "moment-timezone": "^0.5.46",
     "typescript": "^5.7"
   },
   "devDependencies": {

--- a/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
@@ -1,6 +1,7 @@
 import LoadProfile from '../../LoadProfile';
 import times from 'lodash/times';
 import MonthlyEnergy from '../MonthlyEnergy';
+import { sum } from 'lodash';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 
@@ -19,6 +20,7 @@ describe('MonthlyEnergy', () => {
       const result = new MonthlyEnergy(loadProfile).calculate();
 
       expect(result).toEqual(hoursPerMonth);
+      expect(sum(result)).toEqual(8760);
     });
   });
 });

--- a/src/rateEngine/utils/assumptions.ts
+++ b/src/rateEngine/utils/assumptions.ts
@@ -1,6 +1,6 @@
-import moment from 'moment-timezone';
+import { isLeapYear, setYearOnDate } from './datetimes';
 
 export const daysPerMonth = (year?: number): Array<number> => {
-  const isLeapYear = year === undefined ? false : moment(year, 'Y').isLeapYear();
-  return [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const _isLeapYear = year === undefined ? false : isLeapYear(setYearOnDate(new Date(), year));
+  return [31, _isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 };

--- a/src/rateEngine/utils/datetimes.ts
+++ b/src/rateEngine/utils/datetimes.ts
@@ -1,0 +1,18 @@
+// From ChatGPT
+// A year is a leap year if:
+// - it is divisible by 4, and
+// - if divisible by 100, it must also be divisible by 400.
+export function isLeapYear(_year: number | Date) {
+  const year = typeof _year === 'number' ? _year : _year.getFullYear();
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function setYearOnDate(date: Date, year: number) {
+  date.setFullYear(year);
+  return date;
+}
+
+export function zeroDate(date: Date) {
+    // Set the date to the beginning of the year (January 1st, 00:00:00)
+    return new Date(date.getFullYear(), 0, 1, 2, 0, 0); // (year, month, day)
+  }

--- a/src/rateEngine/utils/datetimes.ts
+++ b/src/rateEngine/utils/datetimes.ts
@@ -11,8 +11,3 @@ export function setYearOnDate(date: Date, year: number) {
   date.setFullYear(year);
   return date;
 }
-
-export function zeroDate(date: Date) {
-    // Set the date to the beginning of the year (January 1st, 00:00:00)
-    return new Date(date.getFullYear(), 0, 1, 2, 0, 0); // (year, month, day)
-  }

--- a/src/rateEngine/utils/expandedDates.ts
+++ b/src/rateEngine/utils/expandedDates.ts
@@ -1,24 +1,23 @@
-import moment from 'moment-timezone';
+import dayjs from "dayjs";
 import times from 'lodash/times';
 import type { ExpandedDate } from '../types';
-
-moment.tz.setDefault('America/New_York');
+import { isLeapYear } from './datetimes';
 
 const dates: Record<number, Array<ExpandedDate>> = {};
 
 const generateDates = (year: number): Array<ExpandedDate> => {
-  const profileTime = moment(year, 'Y');
+  let profileTime = dayjs().year(year).month(0).date(1).hour(0).minute(0).second(0);
 
-  return times(profileTime.isLeapYear() ? 8784 : 8760, (hourOfYear) => {
+  return times(isLeapYear(profileTime.toDate()) ? 8784 : 8760, (hourOfYear) => {
     const val = {
-      month: profileTime.month(),
-      dayOfWeek: profileTime.day(),
+      month: profileTime.month(), // 0-based, January is 0
+      dayOfWeek: profileTime.day(), // 0-based, Sunday is 0
       hourStart: profileTime.hour(),
       date: profileTime.format('YYYY-MM-DD'),
       hourOfYear,
     };
 
-    profileTime.add(1, 'hour');
+    profileTime = profileTime.add(1, "hour")
     return val;
   });
 };
@@ -29,4 +28,4 @@ export default (year: number): Array<ExpandedDate> => {
   }
 
   return dates[year];
-}
+};


### PR DESCRIPTION
Moment.js is a pretty large dependency, dayjs on the other hand is much smaller and provides a lot of the same functionality. We're not using `moment` widely in this app so replacing it with `dayjs` was pretty straightforward.

I tried at first to replace `moment` with javascript's Date class but the DST stuff was getting to me and dayjs made it easy.

This PR includes code from the  [package](https://github.com/dcordz/electric-rate-engine/tree/package) branch