### PR TITLE
2. Rollup Rebase

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+lib/
+node_modules/

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,24 @@
+name: Jest
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -1,0 +1,19 @@
+name: Test Feature Branch
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - "*"
+      - "!main" # main branch tests are launched from the deploy-meta.yml meta-workflow
+    tags:
+      - "v*.*.*"
+
+jobs:
+  test:
+    uses: ./.github/workflows/jest.yml
+    secrets: inherit
+  typescript:
+    uses: "./.github/workflows/typescript.yml"
+    secrets: inherit

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,24 @@
+name: Typescript
+
+on:
+  workflow_call:
+
+jobs:
+  tsc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Build the project
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 node_modules
 /lib
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .DS_Store
 tags
 .npmrc
+
+# Rollup visualizer
+stats.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-slim
+
+RUN mkdir electric-rate-engine
+WORKDIR electric-rate-engine
+
+COPY package.json package-lock.json .
+
+RUN npm i
+
+COPY . .
+
+ENTRYPOINT ["npm", "run", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:22-slim
 
 RUN mkdir electric-rate-engine
-WORKDIR electric-rate-engine
+WORKDIR /electric-rate-engine
 
 COPY package.json package-lock.json .
 
 RUN npm i
 
-COPY . ./
+COPY ./ ./
 
 ENTRYPOINT ["npm", "run", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ COPY package.json package-lock.json .
 
 RUN npm i
 
-COPY . .
+COPY . ./
 
 ENTRYPOINT ["npm", "run", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:22-slim
 
-RUN mkdir electric-rate-engine
-WORKDIR /electric-rate-engine
+RUN useradd --user-group --system --create-home --home-dir /home/bellawatt --shell /bin/bash --no-log-init --uid 1001 bellawatt
 
-COPY package.json package-lock.json .
+USER bellawatt
 
-RUN npm i
+WORKDIR /home/bellawatt/electric-rate-engine
+
+COPY --chown=bellawatt package.json ./
+COPY --chown=bellawatt package-lock.json ./
+
+RUN npm install
 
 COPY ./ ./
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,7 @@ export default [
             "lib/",
             "node_modules/",
             "eslint.config.js",
+            "rollup.config.js",
             "**/__mocks__",
             "**/__tests__",
         ],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+// jest.config.ts
+import { createDefaultEsmPreset, JestConfigWithTsJest } from 'ts-jest';
+
+const jestConfig: JestConfigWithTsJest = {
+  ...createDefaultEsmPreset(),
+  testMatch: ["<rootDir>/src/**/*.test.ts"],
+  bail: false
+};
+
+export default jestConfig;

--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,7 +1,0 @@
-{
-  "transform": {
-    "^.+\\.(t|j)sx?$": "ts-jest"
-  },
-  "testMatch": ["<rootDir>/src/**/*.test.ts"],
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dayjs": "^1.11.13",
         "goal-seek": "^0.1.4",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "typescript": "^5.7"
       },
       "devDependencies": {
@@ -33,11 +33,11 @@
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^29.7.0",
-        "lodash-es": "^4.17.21",
         "rollup": "^4.31.0",
         "rollup-plugin-dts": "^6.1.1",
         "source-map-explorer": "^2.5.3",
         "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typescript-eslint": "^8.21.0"
       }
@@ -571,6 +571,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -1486,34 +1510,6 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
-      "integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
-      "integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.31.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
@@ -1526,230 +1522,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
-      "integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
-      "integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
-      "integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
-      "integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
-      "integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
-      "integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
-      "integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
-      "integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
-      "integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
-      "integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
-      "integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
-      "integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
-      "integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
-      "integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
-      "integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
-      "integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -1785,6 +1557,34 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1906,6 +1706,16 @@
       "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.10.7",
@@ -2162,6 +1972,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -3101,6 +2924,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -5993,6 +5826,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -7747,6 +7587,50 @@
         }
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -8007,6 +7891,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -8229,6 +8120,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/lodash-es": "^4.17.12",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
         "@typescript-eslint/parser": "^8.21.0",
-        "cross-env": "^7.0.3",
         "eslint": "^9.18.0",
         "eslint-import-resolver-typescript": "^3.7.0",
         "eslint-plugin-import": "^2.31.0",
@@ -73,9 +72,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -113,13 +112,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -131,14 +123,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -148,13 +140,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -207,9 +199,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -261,13 +253,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -531,17 +523,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -560,9 +552,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -642,6 +634,30 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/core": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
@@ -677,6 +693,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -1170,13 +1210,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -1334,34 +1367,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -1479,19 +1484,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1909,16 +1901,16 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2094,32 +2086,6 @@
         "typescript": ">=4.8.4 <5.8.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
@@ -2203,6 +2169,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2245,6 +2212,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2268,6 +2236,26 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2582,19 +2570,20 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -2611,9 +2600,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -2648,6 +2637,7 @@
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
       },
@@ -2756,9 +2746,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -2863,6 +2853,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2874,7 +2865,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -2893,13 +2885,14 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2924,6 +2917,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
-      "integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==",
+      "version": "1.5.84",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.84.tgz",
+      "integrity": "sha512-I+DQ8xgafao9Ha6y0qjHHvpZ9OfyA1qKlkHkjywxzniORU2awxyz7f/iVJcULmrF2yrM3nHQf+iDjJtbbexd/g==",
       "dev": true,
       "license": "ISC"
     },
@@ -3185,10 +3185,11 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.0",
@@ -3215,28 +3216,29 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.6.tgz",
-      "integrity": "sha512-Ifco6n3yj2tMZDWNLyloZrytt9lqqlwvS83P3HtaETR0NUOYnIULGGHpktqYGObGy+8wc1okO25p8TjemhImvA==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
+        "array-buffer-byte-length": "^1.0.2",
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
+        "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.7",
-        "get-intrinsic": "^1.2.6",
-        "get-symbol-description": "^1.0.2",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
@@ -3244,31 +3246,33 @@
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
         "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.4",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
-        "is-shared-array-buffer": "^1.0.3",
+        "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.13",
+        "is-typed-array": "^1.1.15",
         "is-weakref": "^1.1.0",
-        "math-intrinsics": "^1.0.0",
+        "math-intrinsics": "^1.1.0",
         "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
         "regexp.prototype.flags": "^1.5.3",
         "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.3",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.16"
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3298,9 +3302,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3311,15 +3315,16 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3563,6 +3568,17 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -3571,6 +3587,19 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -3613,12 +3642,29 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/eslint-plugin-promise": {
       "version": "7.2.1",
@@ -3685,6 +3731,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
@@ -3696,6 +3753,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -3791,6 +3861,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3849,12 +3920,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3862,7 +3934,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3885,7 +3957,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3895,9 +3968,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3912,6 +3985,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -3935,16 +4023,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -4024,8 +4102,9 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4098,27 +4177,28 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4135,6 +4215,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4169,9 +4263,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4182,16 +4276,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4213,6 +4308,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -4312,6 +4431,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4454,8 +4574,9 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4463,9 +4584,10 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4475,7 +4597,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4518,13 +4641,16 @@
       "license": "MIT"
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4590,9 +4716,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4687,6 +4813,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4702,13 +4829,16 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4749,19 +4879,6 @@
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -5073,6 +5190,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -5575,6 +5716,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -5709,7 +5863,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5843,8 +5998,9 @@
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5893,7 +6049,8 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -5946,6 +6103,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5957,16 +6127,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -6002,8 +6175,9 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6142,8 +6316,9 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -6197,6 +6372,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -6286,8 +6479,9 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6317,13 +6511,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6471,10 +6665,11 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6535,19 +6730,19 @@
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.9.tgz",
-      "integrity": "sha512-r0Ay04Snci87djAsI4U+WNRcSw5S4pOH7qFjd/veA5gC7TbqESR3tcj28ia95L/fYUDw11JKP7uqUKUAfVvV5Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "dunder-proto": "^1.0.1",
-        "es-abstract": "^1.23.6",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
         "which-builtin-type": "^1.2.1"
       },
       "engines": {
@@ -6558,15 +6753,17 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -6579,8 +6776,9 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6811,6 +7009,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -6881,6 +7096,21 @@
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7066,6 +7296,13 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/source-map-explorer/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/source-map-explorer/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -7181,6 +7418,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -7307,6 +7551,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7394,6 +7639,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tmpl": {
@@ -7636,9 +7905,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7698,9 +7967,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "dev": true,
       "funding": [
         {
@@ -7719,7 +7988,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -7729,10 +7998,11 @@
       }
     },
     "node_modules/uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7751,13 +8021,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -7904,8 +8167,9 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
       "devDependencies": {
         "@eslint/compat": "^1.2.4",
         "@eslint/js": "^9.17.0",
+        "@rollup/plugin-commonjs": "^28.0.2",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^12.1.2",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.17.13",
         "@typescript-eslint/eslint-plugin": "^8.18.1",
@@ -28,8 +33,11 @@
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^29.7.0",
+        "rollup": "^4.30.1",
+        "rollup-plugin-dts": "^6.1.1",
         "source-map-explorer": "^2.5.3",
         "ts-jest": "^29.2.5",
+        "tslib": "^2.8.1",
         "typescript-eslint": "^8.18.1"
       }
     },
@@ -1219,6 +1227,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -1284,6 +1303,459 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
+      "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.0.tgz",
+      "integrity": "sha512-0FPvAeVUT/zdWoO0jnb/V5BlBsUSNfkIOtFHzMO4H9MOklrmQFY6FduVHKucNb/aTFxvnGhj4MNj/T1oNdDfNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.2.tgz",
+      "integrity": "sha512-cdtSp154H5sv637uMr1a8OTWB0L1SWDSm1rDGiyfcGcvQ6cuTs4MDk2BVEBGysUWago4OJN4EQZqOTl/QY3Jgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1449,6 +1921,13 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2394,6 +2873,20 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3282,6 +3775,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4240,6 +4740,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -4278,6 +4785,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/is-regex": {
@@ -5343,6 +5860,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -5987,6 +6514,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -6144,6 +6681,68 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.30.1",
+        "@rollup/rollup-android-arm64": "4.30.1",
+        "@rollup/rollup-darwin-arm64": "4.30.1",
+        "@rollup/rollup-darwin-x64": "4.30.1",
+        "@rollup/rollup-freebsd-arm64": "4.30.1",
+        "@rollup/rollup-freebsd-x64": "4.30.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+        "@rollup/rollup-linux-arm64-musl": "4.30.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-musl": "4.30.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+        "@rollup/rollup-win32-x64-msvc": "4.30.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+      "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "magic-string": "^0.30.10"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.24.2"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6188,6 +6787,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -6217,6 +6837,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -6375,6 +7005,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/smob": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
+      "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -6711,6 +7348,36 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/terser": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6843,6 +7510,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,30 +15,32 @@
         "typescript": "^5.7"
       },
       "devDependencies": {
-        "@eslint/compat": "^1.2.4",
-        "@eslint/js": "^9.17.0",
+        "@eslint/compat": "^1.2.5",
+        "@eslint/js": "^9.18.0",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/jest": "^29.5.14",
-        "@types/lodash": "^4.17.13",
-        "@typescript-eslint/eslint-plugin": "^8.18.1",
-        "@typescript-eslint/parser": "^8.18.1",
-        "eslint": "^9.17.0",
+        "@types/lodash-es": "^4.17.12",
+        "@typescript-eslint/eslint-plugin": "^8.21.0",
+        "@typescript-eslint/parser": "^8.21.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^9.18.0",
         "eslint-import-resolver-typescript": "^3.7.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^29.7.0",
-        "rollup": "^4.30.1",
+        "lodash-es": "^4.17.21",
+        "rollup": "^4.31.0",
         "rollup-plugin-dts": "^6.1.1",
         "source-map-explorer": "^2.5.3",
         "ts-jest": "^29.2.5",
         "tslib": "^2.8.1",
-        "typescript-eslint": "^8.18.1"
+        "typescript-eslint": "^8.21.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -608,9 +610,9 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
-      "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.5.tgz",
+      "integrity": "sha512-5iuG/StT+7OfvhoBHPlmxkPA9om6aDUFgmD4+mWKAGsYt4vCe8rypneG03AuseyRHBmcCLXQtIH5S26tIoggLg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -641,9 +643,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -678,9 +680,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
+      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -698,12 +700,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.10.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1492,9 +1495,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
-      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
+      "integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
       "cpu": [
         "arm"
       ],
@@ -1506,9 +1509,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
-      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
+      "integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
       "cpu": [
         "arm64"
       ],
@@ -1520,9 +1523,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
-      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
+      "integrity": "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==",
       "cpu": [
         "arm64"
       ],
@@ -1534,9 +1537,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
-      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
+      "integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
       "cpu": [
         "x64"
       ],
@@ -1548,9 +1551,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
-      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
+      "integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
       "cpu": [
         "arm64"
       ],
@@ -1562,9 +1565,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
-      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
+      "integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
       "cpu": [
         "x64"
       ],
@@ -1576,9 +1579,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
-      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
+      "integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
       "cpu": [
         "arm"
       ],
@@ -1590,9 +1593,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
-      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
+      "integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
       "cpu": [
         "arm"
       ],
@@ -1604,9 +1607,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
-      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
+      "integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
       "cpu": [
         "arm64"
       ],
@@ -1618,9 +1621,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
-      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
+      "integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
       "cpu": [
         "arm64"
       ],
@@ -1632,9 +1635,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
-      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
+      "integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
       "cpu": [
         "loong64"
       ],
@@ -1646,9 +1649,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
-      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
+      "integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1660,9 +1663,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
-      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
+      "integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
       "cpu": [
         "riscv64"
       ],
@@ -1674,9 +1677,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
-      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
+      "integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
       "cpu": [
         "s390x"
       ],
@@ -1688,9 +1691,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
-      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
+      "integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
       "cpu": [
         "x64"
       ],
@@ -1702,9 +1705,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
-      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
+      "integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
       "cpu": [
         "x64"
       ],
@@ -1716,9 +1719,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
-      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
+      "integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +1733,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
-      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
+      "integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
       "cpu": [
         "ia32"
       ],
@@ -1744,9 +1747,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
-      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
+      "integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
       "cpu": [
         "x64"
       ],
@@ -1954,21 +1957,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
-      "integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.21.0.tgz",
+      "integrity": "sha512-eTH+UOR4I7WbdQnG4Z48ebIA6Bgi7WO8HvFEneeYBxG8qCOYgTOFPSg6ek9ITIDvGjDQzWHcoWHCDO2biByNzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/type-utils": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/scope-manager": "8.21.0",
+        "@typescript-eslint/type-utils": "8.21.0",
+        "@typescript-eslint/utils": "8.21.0",
+        "@typescript-eslint/visitor-keys": "8.21.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1984,16 +1987,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
-      "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.21.0.tgz",
+      "integrity": "sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/typescript-estree": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/scope-manager": "8.21.0",
+        "@typescript-eslint/types": "8.21.0",
+        "@typescript-eslint/typescript-estree": "8.21.0",
+        "@typescript-eslint/visitor-keys": "8.21.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2009,14 +2012,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
-      "integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.21.0.tgz",
+      "integrity": "sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1"
+        "@typescript-eslint/types": "8.21.0",
+        "@typescript-eslint/visitor-keys": "8.21.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2027,16 +2030,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
-      "integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.21.0.tgz",
+      "integrity": "sha512-95OsL6J2BtzoBxHicoXHxgk3z+9P3BEcQTpBKriqiYzLKnM2DeSqs+sndMKdamU8FosiadQFT3D+BSL9EKnAJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.21.0",
+        "@typescript-eslint/utils": "8.21.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2051,9 +2054,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
-      "integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.21.0.tgz",
+      "integrity": "sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2065,20 +2068,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
-      "integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.21.0.tgz",
+      "integrity": "sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/types": "8.21.0",
+        "@typescript-eslint/visitor-keys": "8.21.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2118,16 +2121,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
-      "integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
+      "integrity": "sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/typescript-estree": "8.18.1"
+        "@typescript-eslint/scope-manager": "8.21.0",
+        "@typescript-eslint/types": "8.21.0",
+        "@typescript-eslint/typescript-estree": "8.21.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2142,13 +2145,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
-      "integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.21.0.tgz",
+      "integrity": "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/types": "8.21.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3381,19 +3384,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
+      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
+        "@eslint/core": "^0.10.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/js": "9.18.0",
+        "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.1",
@@ -6682,9 +6685,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.31.0.tgz",
+      "integrity": "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6698,25 +6701,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.30.1",
-        "@rollup/rollup-android-arm64": "4.30.1",
-        "@rollup/rollup-darwin-arm64": "4.30.1",
-        "@rollup/rollup-darwin-x64": "4.30.1",
-        "@rollup/rollup-freebsd-arm64": "4.30.1",
-        "@rollup/rollup-freebsd-x64": "4.30.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
-        "@rollup/rollup-linux-arm64-musl": "4.30.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-musl": "4.30.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
-        "@rollup/rollup-win32-x64-msvc": "4.30.1",
+        "@rollup/rollup-android-arm-eabi": "4.31.0",
+        "@rollup/rollup-android-arm64": "4.31.0",
+        "@rollup/rollup-darwin-arm64": "4.31.0",
+        "@rollup/rollup-darwin-x64": "4.31.0",
+        "@rollup/rollup-freebsd-arm64": "4.31.0",
+        "@rollup/rollup-freebsd-x64": "4.31.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.31.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.31.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.31.0",
+        "@rollup/rollup-linux-arm64-musl": "4.31.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.31.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.31.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.31.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-musl": "4.31.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.31.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.31.0",
+        "@rollup/rollup-win32-x64-msvc": "4.31.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -7414,16 +7417,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -7646,15 +7649,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.1.tgz",
-      "integrity": "sha512-Mlaw6yxuaDEPQvb/2Qwu3/TfgeBHy9iTJ3mTwe7OvpPmF6KPQjVOfGyEJpPv6Ez2C34OODChhXrzYw/9phI0MQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.21.0.tgz",
+      "integrity": "sha512-txEKYY4XMKwPXxNkN8+AxAdX6iIJAPiJbHE/FpQccs/sxw8Lf26kqwC3cn0xkHlW8kEbLhkhCsjWuMveaY9Rxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.18.1",
-        "@typescript-eslint/parser": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1"
+        "@typescript-eslint/eslint-plugin": "8.21.0",
+        "@typescript-eslint/parser": "8.21.0",
+        "@typescript-eslint/utils": "8.21.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
-    "build": "rm -rf lib && tsc -p tsconfig.build.json && npm run build-rollup",
+    "build": "rm -rf lib && npm run build-rollup",
     "build-rollup": "rollup -c rollup.config.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "analyze": "source-map-explorer 'lib/**/*.js' --no-border-checks",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Electric Rate Engine",
   "type": "module",
-  "main": "./lib/commonjs/index.js",
+  "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -2,14 +2,9 @@
   "name": "@bellawatt/electric-rate-engine",
   "version": "2.0.1",
   "description": "Electric Rate Engine",
-<<<<<<< HEAD
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
-=======
   "type": "module",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
->>>>>>> 34b4662 (rollup - packaging with rollup)
   "files": [
     "lib"
   ],
@@ -18,8 +13,7 @@
   "scripts": {
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
-    "build": "rm -rf lib && npm run build-rollup",
-    "build-rollup": "rollup -c rollup.config.js",
+    "build": "rm -rf lib && rollup -c rollup.config.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "analyze": "source-map-explorer 'lib/**/*.js' --no-border-checks",
     "lint": "npx eslint -c eslint.config.js src"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,14 @@
   "name": "@bellawatt/electric-rate-engine",
   "version": "2.0.1",
   "description": "Electric Rate Engine",
+<<<<<<< HEAD
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+=======
+  "type": "module",
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/esm/index.js",
+>>>>>>> 34b4662 (rollup - packaging with rollup)
   "files": [
     "lib"
   ],
@@ -12,7 +18,8 @@
   "scripts": {
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "rm -rf lib && tsc -p tsconfig.build.json && npm run build-rollup",
+    "build-rollup": "rollup -c rollup.config.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "analyze": "source-map-explorer 'lib/**/*.js' --no-border-checks",
     "lint": "npx eslint -c eslint.config.js src"
@@ -28,6 +35,11 @@
   "devDependencies": {
     "@eslint/compat": "^1.2.4",
     "@eslint/js": "^9.17.0",
+    "@rollup/plugin-commonjs": "^28.0.2",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.2",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.13",
     "@typescript-eslint/eslint-plugin": "^8.18.1",
@@ -39,8 +51,11 @@
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.7.0",
+    "rollup": "^4.30.1",
+    "rollup-plugin-dts": "^6.1.1",
     "source-map-explorer": "^2.5.3",
     "ts-jest": "^29.2.5",
+    "tslib": "^2.8.1",
     "typescript-eslint": "^8.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,33 +23,34 @@
   "dependencies": {
     "dayjs": "^1.11.13",
     "goal-seek": "^0.1.4",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "typescript": "^5.7"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.4",
-    "@eslint/js": "^9.17.0",
+    "@eslint/compat": "^1.2.5",
+    "@eslint/js": "^9.18.0",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/jest": "^29.5.14",
-    "@types/lodash": "^4.17.13",
-    "@typescript-eslint/eslint-plugin": "^8.18.1",
-    "@typescript-eslint/parser": "^8.18.1",
-    "eslint": "^9.17.0",
+    "@types/lodash-es": "^4.17.12",
+    "@typescript-eslint/eslint-plugin": "^8.21.0",
+    "@typescript-eslint/parser": "^8.21.0",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.18.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.7.0",
-    "rollup": "^4.30.1",
+    "rollup": "^4.31.0",
     "rollup-plugin-dts": "^6.1.1",
     "source-map-explorer": "^2.5.3",
     "ts-jest": "^29.2.5",
     "tslib": "^2.8.1",
-    "typescript-eslint": "^8.18.1"
+    "typescript-eslint": "^8.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "source-map-explorer": "^2.5.3",
     "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "typescript-eslint": "^8.21.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "repository": "git://github.com/bellawatt/electric-rate-engine.git",
   "scripts": {
     "test": "TZ=America/New_York NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.ts",
+    "test:docker": "docker build . -t electric-rate-engine-tests && docker run -it --rm electric-rate-engine-tests",
     "test:watch": "jest --config jest.config.ts --watch",
     "build": "rm -rf lib && rollup -c rollup.config.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "repository": "git://github.com/bellawatt/electric-rate-engine.git",
   "scripts": {
-    "test": "jest --config jestconfig.json",
-    "test:watch": "jest --config jestconfig.json --watch",
+    "test": "TZ=America/New_York NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.ts",
+    "test:watch": "jest --config jest.config.ts --watch",
     "build": "rm -rf lib && rollup -c rollup.config.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "analyze": "source-map-explorer 'lib/**/*.js' --no-border-checks",
@@ -38,7 +38,6 @@
     "@types/lodash-es": "^4.17.12",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
     "@typescript-eslint/parser": "^8.21.0",
-    "cross-env": "^7.0.3",
     "eslint": "^9.18.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,8 +25,8 @@ export default [
   {
     input: './src/index.ts',
     output: [
+      { file: "./lib/commonjs/index.d.ts", format: "cjs" },
       { file: "./lib/esm/index.d.ts", format: "es" },
-      { file: "./lib/commonjs/index.d.ts", format: "es" },
     ],
     plugins: [
       dts({ tsconfig: "./tsconfig.build.json", emitDeclarationOnly: true }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ export default [
   {
     input: './src/index.ts',
     output: [
-      { file: "./lib/commonjs/index.d.ts", format: "cjs" },
+      { file: "./lib/cjs/index.d.ts", format: "cjs" },
       { file: "./lib/esm/index.d.ts", format: "es" },
     ],
     plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,6 @@
+import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import { dts } from 'rollup-plugin-dts';
 import pkg from './package.json' with { type: "json" };
@@ -36,8 +38,7 @@ export default [
   {
     input: './src/index.ts',
     output: [
-      { file: "./lib/cjs/index.d.ts", format: "cjs" },
-      { file: "./lib/esm/index.d.ts", format: "es" },
+      { file: "./lib/index.d.ts", format: "es" },
     ],
     plugins: [
       dts({ tsconfig: "./tsconfig.build.json", emitDeclarationOnly: true }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ export default [
       json(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.build.json", declaration: false, noEmit: true, emitDeclarationOnly: false, allowImportingTsExtensions: true }),
+      typescript({ tsconfig: "./tsconfig.build.json", declaration: false }),
       // terser()
     ],
   },
@@ -29,7 +29,7 @@ export default [
       { file: "./lib/esm/index.d.ts", format: "es" },
     ],
     plugins: [
-      dts({ tsconfig: "./tsconfig.build.json", noEmit: true, emitDeclarationOnly: true }),
+      dts({ tsconfig: "./tsconfig.build.json", emitDeclarationOnly: true }),
     ],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,35 @@
+import json from '@rollup/plugin-json';
+import typescript from '@rollup/plugin-typescript';
+import { dts } from 'rollup-plugin-dts';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import terser from '@rollup/plugin-terser';
+import pkg from './package.json'  with { type: "json"};
+
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      { file: pkg.main, format: 'cjs' },
+      { file: pkg.module, format: 'es' },
+    ],
+    plugins: [
+      json(),
+      resolve(),
+      commonjs(),
+      typescript({ tsconfig: "./tsconfig.build.json", declaration: false }),
+      terser()
+    ],
+  },
+
+  {
+    input: './src/index.ts',
+    output: [
+      { file: "./lib/esm/index.d.ts", format: "es" },
+      { file: "./lib/commonjs/index.d.ts", format: "es" },
+    ],
+    plugins: [
+      dts({ tsconfig: "./tsconfig.build.json", emitDeclarationOnly: true }),
+    ],
+  },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,8 +17,8 @@ export default [
       json(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.build.json", declaration: false }),
-      terser()
+      typescript({ tsconfig: "./tsconfig.build.json", declaration: false, noEmit: true, emitDeclarationOnly: false, allowImportingTsExtensions: true }),
+      // terser()
     ],
   },
 
@@ -29,7 +29,7 @@ export default [
       { file: "./lib/esm/index.d.ts", format: "es" },
     ],
     plugins: [
-      dts({ tsconfig: "./tsconfig.build.json", emitDeclarationOnly: true }),
+      dts({ tsconfig: "./tsconfig.build.json", noEmit: true, emitDeclarationOnly: true }),
     ],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,21 @@
 import json from '@rollup/plugin-json';
 import typescript from '@rollup/plugin-typescript';
 import { dts } from 'rollup-plugin-dts';
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import terser from '@rollup/plugin-terser';
-import pkg from './package.json'  with { type: "json"};
+import pkg from './package.json' with { type: "json" };
+import { statSync } from 'fs';
+
+const logBundleSize = () => {
+  return {
+    name: 'log-bundle-size',
+    writeBundle(options) {
+      const { file } = options;
+      if (file) {
+        const size = statSync(file).size / 1024; // Convert to KB
+        console.log(`${file} size ${size.toFixed(2)} KB`);
+      }
+    },
+  };
+};
 
 export default [
   {
@@ -18,7 +29,7 @@ export default [
       resolve(),
       commonjs(),
       typescript({ tsconfig: "./tsconfig.build.json", declaration: false }),
-      // terser()
+      logBundleSize()
     ],
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export { default as RateCalculator } from './rateEngine/RateCalculator.ts';
 export { default as LoadProfile } from './rateEngine/LoadProfile.ts';
+export { default as RateElement } from './rateEngine/RateElement.ts';
+export { default as RateComponent } from './rateEngine/RateComponent.ts';
 
 export * from './rateEngine/constants/index.ts';
 export * from './rateEngine/types/index.ts';
 
-export const RateEngineVersion = "2.0.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export { default as LoadProfile } from './rateEngine/LoadProfile.ts';
 
 export * from './rateEngine/constants/index.ts';
 export * from './rateEngine/types/index.ts';
+
+export const RateEngineVersion = "2.0.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export {default as RateCalculator} from './rateEngine/RateCalculator';
-export {default as LoadProfile} from './rateEngine/LoadProfile';
+export { default as RateCalculator } from './rateEngine/RateCalculator.ts';
+export { default as LoadProfile } from './rateEngine/LoadProfile.ts';
 
-export * from "./rateEngine/constants"
-export * from './rateEngine/types';
+export * from './rateEngine/constants/index.ts';
+export * from './rateEngine/types/index.ts';

--- a/src/rateEngine/BillingDeterminantsFactory.ts
+++ b/src/rateEngine/BillingDeterminantsFactory.ts
@@ -1,20 +1,20 @@
-import AnnualDemand from './billingDeterminants/AnnualDemand';
-import BlockedTiersInDays from './billingDeterminants/BlockedTiersInDays';
-import BlockedTiersInMonths from './billingDeterminants/BlockedTiersInMonths';
-import DemandPerDay from './billingDeterminants/DemandPerDay';
-import DemandTiersInMonths from './billingDeterminants/DemandTiersInMonths';
-import DemandTimeOfUse from './billingDeterminants/DemandTimeOfUse';
-import EnergyTimeOfUse from './billingDeterminants/EnergyTimeOfUse';
-import FixedPerDay from './billingDeterminants/FixedPerDay';
-import FixedPerMonth from './billingDeterminants/FixedPerMonth';
-import HourlyEnergy from './billingDeterminants/HourlyEnergy';
-import MonthlyDemand from './billingDeterminants/MonthlyDemand';
-import MonthlyEnergy from './billingDeterminants/MonthlyEnergy';
-import SurchargeAsPercent from './billingDeterminants/SurchargeAsPercent';
-import LoadProfile from './LoadProfile';
+import AnnualDemand from './billingDeterminants/AnnualDemand.ts';
+import BlockedTiersInDays from './billingDeterminants/BlockedTiersInDays.ts';
+import BlockedTiersInMonths from './billingDeterminants/BlockedTiersInMonths.ts';
+import DemandPerDay from './billingDeterminants/DemandPerDay.ts';
+import DemandTiersInMonths from './billingDeterminants/DemandTiersInMonths.ts';
+import DemandTimeOfUse from './billingDeterminants/DemandTimeOfUse.ts';
+import EnergyTimeOfUse from './billingDeterminants/EnergyTimeOfUse.ts';
+import FixedPerDay from './billingDeterminants/FixedPerDay.ts';
+import FixedPerMonth from './billingDeterminants/FixedPerMonth.ts';
+import HourlyEnergy from './billingDeterminants/HourlyEnergy.ts';
+import MonthlyDemand from './billingDeterminants/MonthlyDemand.ts';
+import MonthlyEnergy from './billingDeterminants/MonthlyEnergy.ts';
+import SurchargeAsPercent from './billingDeterminants/SurchargeAsPercent.ts';
+import LoadProfile from './LoadProfile.ts';
 import type {
   ProcessedRateElementInterface,
-} from './types';
+} from './types/index.ts';
 
 class BillingDeterminantsFactory {
   static make(

--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -1,4 +1,4 @@
-import { maxBy, times } from 'lodash';
+import { maxBy, times } from "lodash-es";
 import LoadProfileFilter from './LoadProfileFilter.ts';
 import LoadProfileScaler from './LoadProfileScaler.ts';
 import type {

--- a/src/rateEngine/LoadProfile.ts
+++ b/src/rateEngine/LoadProfile.ts
@@ -1,15 +1,14 @@
-import maxBy from 'lodash/maxBy';
-import times from 'lodash/times';
-import LoadProfileFilter from './LoadProfileFilter';
-import LoadProfileScaler from './LoadProfileScaler';
+import { maxBy, times } from 'lodash';
+import LoadProfileFilter from './LoadProfileFilter.ts';
+import LoadProfileScaler from './LoadProfileScaler.ts';
 import type {
   DetailedLoadProfileHour,
   LoadProfileFilterArgs,
   LoadProfileOptions,
   LoadProfileScalerOptions,
-} from './types';
-import { addDecimals } from './utils/decimals';
-import expandedDates from './utils/expandedDates';
+} from './types/index.ts';
+import { addDecimals } from './utils/decimals.ts';
+import expandedDates from './utils/expandedDates.ts';
 
 const isLoadProfileObject = (p: Array<number> | Array<DetailedLoadProfileHour> | LoadProfile): p is LoadProfile => {
   return 'expanded' in p && typeof p['expanded'] === 'function';

--- a/src/rateEngine/LoadProfileFilter.ts
+++ b/src/rateEngine/LoadProfileFilter.ts
@@ -1,4 +1,4 @@
-import type { LoadProfileFilterArgs, ExpandedDate } from './types';
+import type { LoadProfileFilterArgs, ExpandedDate } from './types/index.ts';
 
 class LoadProfileFilter {
   months?: Array<number>;

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -6,6 +6,8 @@ import type { GoalSeekArgs, LoadProfileScalerOptions, RateInterface } from './ty
 // TODO: use proper math for scaling
 // TODO: fix the toAverageMonthlyBill argument... how to properly pass in a rate?
 
+const gs = ("default" in goalSeek ? goalSeek.default : goalSeek) as (params: GoalSeekArgs) => number;
+
 class LoadProfileScaler {
   loadProfile: LoadProfile;
   debug: boolean;
@@ -34,7 +36,7 @@ class LoadProfileScaler {
     const initialScalerGuess = magnitudeScaler;
     const fnParams = [initialScalerGuess, rate, this, magnitude];
 
-    const finalScaler = goalSeek.default({
+    const finalScaler = this.goalSeek({
       fn: this.scaledMonthlyCost,
       fnParams,
       percentTolerance: 0.1,
@@ -47,6 +49,10 @@ class LoadProfileScaler {
 
     const scalerAsDecimal = finalScaler / magnitudeScaler;
     return this.to(scalerAsDecimal);
+  }
+
+  goalSeek(goalSeekParams: GoalSeekArgs = {}) {
+    return gs(goalSeekParams)
   }
 
   toMonthlyKwh(monthlyKwh: Array<number>): LoadProfile {

--- a/src/rateEngine/LoadProfileScaler.ts
+++ b/src/rateEngine/LoadProfileScaler.ts
@@ -1,7 +1,7 @@
-import LoadProfile from './LoadProfile';
-import RateCalculator from './RateCalculator';
+import LoadProfile from './LoadProfile.ts';
+import RateCalculator from './RateCalculator.ts';
 import goalSeek from 'goal-seek';
-import type { GoalSeekArgs, LoadProfileScalerOptions, RateInterface } from './types';
+import type { GoalSeekArgs, LoadProfileScalerOptions, RateInterface } from './types/index.ts';
 
 // TODO: use proper math for scaling
 // TODO: fix the toAverageMonthlyBill argument... how to properly pass in a rate?
@@ -34,7 +34,7 @@ class LoadProfileScaler {
     const initialScalerGuess = magnitudeScaler;
     const fnParams = [initialScalerGuess, rate, this, magnitude];
 
-    const finalScaler = goalSeek({
+    const finalScaler = goalSeek.default({
       fn: this.scaledMonthlyCost,
       fnParams,
       percentTolerance: 0.1,

--- a/src/rateEngine/PriceProfile.ts
+++ b/src/rateEngine/PriceProfile.ts
@@ -1,4 +1,4 @@
-import { maxBy, times } from 'lodash';
+import { maxBy, times } from "lodash-es";
 import LoadProfileFilter from './LoadProfileFilter.ts';
 import type { DetailedPriceProfileHour, LoadProfileFilterArgs, PriceProfileOptions } from './types/index.ts';
 import { addDecimals } from './utils/decimals.ts';

--- a/src/rateEngine/PriceProfile.ts
+++ b/src/rateEngine/PriceProfile.ts
@@ -1,9 +1,8 @@
-import maxBy from 'lodash/maxBy';
-import times from 'lodash/times';
-import LoadProfileFilter from './LoadProfileFilter';
-import type { DetailedPriceProfileHour, LoadProfileFilterArgs, PriceProfileOptions } from './types';
-import { addDecimals } from './utils/decimals';
-import expandedDates from './utils/expandedDates';
+import { maxBy, times } from 'lodash';
+import LoadProfileFilter from './LoadProfileFilter.ts';
+import type { DetailedPriceProfileHour, LoadProfileFilterArgs, PriceProfileOptions } from './types/index.ts';
+import { addDecimals } from './utils/decimals.ts';
+import expandedDates from './utils/expandedDates.ts';
 
 const isPriceProfileObject = (p: Array<number> | Array<DetailedPriceProfileHour> | PriceProfile): p is PriceProfile => {
   return 'expanded' in p && typeof p['expanded'] === 'function';
@@ -25,7 +24,7 @@ class PriceProfile {
     options: PriceProfileOptions,
   ) {
     this._year = options.year;
-    
+
     if (isPriceProfileObject(priceProfileOrExpandedOrExisting)) {
       this._expanded = priceProfileOrExpandedOrExisting.expanded();
     } else if (isNumberArray(priceProfileOrExpandedOrExisting)) {

--- a/src/rateEngine/RateCalculator.ts
+++ b/src/rateEngine/RateCalculator.ts
@@ -1,6 +1,6 @@
-import sum from 'lodash/sum';
-import RateElement from './RateElement';
-import type { RateCalculatorInterface, RateElementFilterArgs } from './types';
+import { sum } from "lodash"
+import RateElement from './RateElement.ts';
+import type { RateCalculatorInterface, RateElementFilterArgs } from './types/index.ts';
 
 class RateCalculator {
   private _rateElements: Array<RateElement>;

--- a/src/rateEngine/RateCalculator.ts
+++ b/src/rateEngine/RateCalculator.ts
@@ -1,4 +1,4 @@
-import { sum } from "lodash"
+import { sum } from "lodash-es"
 import RateElement from './RateElement.ts';
 import type { RateCalculatorInterface, RateElementFilterArgs } from './types/index.ts';
 

--- a/src/rateEngine/RateComponent.ts
+++ b/src/rateEngine/RateComponent.ts
@@ -1,4 +1,4 @@
-import { mean, sum, times } from 'lodash';
+import { mean, sum, times } from "lodash-es";
 import BillingDeterminants from './billingDeterminants/_BillingDeterminants.ts';
 import type { RateComponentArgs } from './types/index.ts';
 import { multiplyDecimals } from './utils/decimals.ts';

--- a/src/rateEngine/RateComponent.ts
+++ b/src/rateEngine/RateComponent.ts
@@ -1,9 +1,7 @@
-import times from 'lodash/times';
-import mean from 'lodash/mean';
-import sum from 'lodash/sum';
-import BillingDeterminants from './billingDeterminants/_BillingDeterminants';
-import { multiplyDecimals } from './utils/decimals';
-import type { RateComponentArgs } from './types';
+import { mean, sum, times } from 'lodash';
+import BillingDeterminants from './billingDeterminants/_BillingDeterminants.ts';
+import type { RateComponentArgs } from './types/index.ts';
+import { multiplyDecimals } from './utils/decimals.ts';
 
 const MONTHS_PER_YEAR = 12;
 

--- a/src/rateEngine/RateComponentsFactory.ts
+++ b/src/rateEngine/RateComponentsFactory.ts
@@ -1,9 +1,9 @@
-import BillingDeterminantsFactory from './BillingDeterminantsFactory';
-import LoadProfile from './LoadProfile';
-import PriceProfile from './PriceProfile';
-import RateComponent from './RateComponent';
-import RateElement from './RateElement';
-import type { RateElementInterface, ProcessedRateElementInterface } from './types';
+import BillingDeterminantsFactory from './BillingDeterminantsFactory.ts';
+import LoadProfile from './LoadProfile.ts';
+import PriceProfile from './PriceProfile.ts';
+import RateComponent from './RateComponent.ts';
+import RateElement from './RateElement.ts';
+import type { RateElementInterface, ProcessedRateElementInterface } from './types/index.ts';
 
 export default class RateComponentsFactory {
   static make(

--- a/src/rateEngine/RateElement.ts
+++ b/src/rateEngine/RateElement.ts
@@ -1,4 +1,4 @@
-import { sum } from 'lodash';
+import { sum } from "lodash-es";
 import RateComponent from './RateComponent.ts';
 import RateCalculator from './RateCalculator.ts';
 import ValidatorFactory from './ValidatorFactory.ts';

--- a/src/rateEngine/RateElement.ts
+++ b/src/rateEngine/RateElement.ts
@@ -1,11 +1,11 @@
-import RateComponent from './RateComponent';
-import RateCalculator from './RateCalculator';
-import sum from 'lodash/sum';
-import ValidatorFactory from './ValidatorFactory';
-import LoadProfile from './LoadProfile';
-import RateComponentsFactory from './RateComponentsFactory';
-import { BillingCategory, RateElementClassification } from './constants';
-import type { RateElementType, RateElementInterface, RateElementFilterArgs, ValidatorError } from './types';
+import { sum } from 'lodash';
+import RateComponent from './RateComponent.ts';
+import RateCalculator from './RateCalculator.ts';
+import ValidatorFactory from './ValidatorFactory.ts';
+import LoadProfile from './LoadProfile.ts';
+import RateComponentsFactory from './RateComponentsFactory.ts';
+import { BillingCategory, RateElementClassification } from './constants/index.ts';
+import type { RateElementType, RateElementInterface, RateElementFilterArgs, ValidatorError } from './types/index.ts';
 
 class RateElement {
   private _rateComponents: Array<RateComponent>;

--- a/src/rateEngine/ValidatorFactory.ts
+++ b/src/rateEngine/ValidatorFactory.ts
@@ -1,9 +1,9 @@
-import Validator from './validators/_Validator';
-import EnergyTimeOfUseValidator from './validators/EnergyTimeOfUseValidator';
-import GenericValidator from './validators/GenericValidator';
-import BlockedTiersValidator from './validators/BlockedTiersValidator';
-import LoadProfile from './LoadProfile';
-import { RateComponentInterface, EnergyTimeOfUseArgs, BlockedTiersArgs, RateElementType } from './types';
+import Validator from './validators/_Validator.ts';
+import EnergyTimeOfUseValidator from './validators/EnergyTimeOfUseValidator.ts';
+import GenericValidator from './validators/GenericValidator.ts';
+import BlockedTiersValidator from './validators/BlockedTiersValidator.ts';
+import LoadProfile from './LoadProfile.ts';
+import { RateComponentInterface, EnergyTimeOfUseArgs, BlockedTiersArgs, RateElementType } from './types/index.ts';
 
 class ValidatorFactory {
   static make(

--- a/src/rateEngine/__mocks__/rates/e-1.ts
+++ b/src/rateEngine/__mocks__/rates/e-1.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from "lodash-es";
 import type { RateInterface } from '../../types/index.ts';
 
 const SUMMMER_MONTHS = [4, 5, 6, 7, 8, 9];

--- a/src/rateEngine/__mocks__/rates/e-1.ts
+++ b/src/rateEngine/__mocks__/rates/e-1.ts
@@ -1,5 +1,5 @@
 import { times } from 'lodash';
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const SUMMMER_MONTHS = [4, 5, 6, 7, 8, 9];
 const cutoff_1 = times(12, (i) => (SUMMMER_MONTHS.includes(i) ? 13 : 12.5));

--- a/src/rateEngine/__mocks__/rates/e-tou-a.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-a.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from "lodash-es";
 import type { RateInterface } from '../../types/index.ts';
 
 const HOLIDAYS = [

--- a/src/rateEngine/__mocks__/rates/e-tou-a.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-a.ts
@@ -1,5 +1,5 @@
 import { times } from 'lodash';
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const HOLIDAYS = [
   '2018-01-01',

--- a/src/rateEngine/__mocks__/rates/e-tou-b.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-b.ts
@@ -1,4 +1,4 @@
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const HOLIDAYS = [
   '2018-01-01',

--- a/src/rateEngine/__mocks__/rates/e-tou-c.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-c.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from "lodash-es";
 import type { RateInterface } from '../../types/index.ts';
 
 const summerPeakCharge = 0.41333;

--- a/src/rateEngine/__mocks__/rates/e-tou-c.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-c.ts
@@ -1,5 +1,5 @@
 import { times } from 'lodash';
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const summerPeakCharge = 0.41333;
 const summmerOffpeakCharge = 0.34989;

--- a/src/rateEngine/__mocks__/rates/e-tou-d.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-d.ts
@@ -1,4 +1,4 @@
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const HOLIDAYS = [
   '2018-01-01',

--- a/src/rateEngine/__mocks__/rates/ev2a.ts
+++ b/src/rateEngine/__mocks__/rates/ev2a.ts
@@ -1,4 +1,4 @@
-import type { RateInterface } from '../../types';
+import type { RateInterface } from '../../types/index.ts';
 
 const summerPeakCharge = 0.47861;
 const summerPartpeakCharge = 0.36812;

--- a/src/rateEngine/__tests__/LoadProfileFilter.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileFilter.test.ts
@@ -1,5 +1,5 @@
-import LoadProfileFilter from '../LoadProfileFilter';
-import { ExpandedDate, LoadProfileFilterArgs } from '../types';
+import LoadProfileFilter from '../LoadProfileFilter.ts';
+import { ExpandedDate, LoadProfileFilterArgs } from '../types/index.ts';
 
 const baseFilter: LoadProfileFilterArgs = {
   months: [],

--- a/src/rateEngine/__tests__/LoadProfileScaler.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.test.ts
@@ -1,6 +1,6 @@
-import LoadProfileScaler from '../LoadProfileScaler';
-import times from 'lodash/times';
-import LoadProfile from '../LoadProfile';
+import LoadProfileScaler from '../LoadProfileScaler.ts';
+import {times} from 'lodash';
+import LoadProfile from '../LoadProfile.ts';
 import goalSeek from 'goal-seek';
 import e1 from '../__mocks__/rates/e-1';
 

--- a/src/rateEngine/__tests__/LoadProfileScaler.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.test.ts
@@ -1,16 +1,14 @@
-import LoadProfileScaler from '../LoadProfileScaler.ts';
-import {times} from 'lodash';
+import { jest } from '@jest/globals';
+import { times } from 'lodash-es';
+import e1 from '../__mocks__/rates/e-1.ts';
 import LoadProfile from '../LoadProfile.ts';
-import goalSeek from 'goal-seek';
-import e1 from '../__mocks__/rates/e-1';
+import LoadProfileScaler from '../LoadProfileScaler.ts';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 const getLoadProfileOfTwos = () => times(8760, () => 2);
 
-jest.mock('goal-seek');
-
 describe('LoadProfileScaler', () => {
-  const initialLoadProfile = new LoadProfile(getLoadProfileOfOnes(), {year: 2019});
+  const initialLoadProfile = new LoadProfile(getLoadProfileOfOnes(), { year: 2019 });
   let loadProfileScaler: LoadProfileScaler;
 
   beforeEach(() => {
@@ -19,10 +17,8 @@ describe('LoadProfileScaler', () => {
 
   describe('to', () => {
     it('multiplies all entries in the load profile by the given scaler', () => {
-      expect(loadProfileScaler.to(2)).toEqual(
-        new LoadProfile(getLoadProfileOfTwos(), {year: 2019})
-      );
-    })
+      expect(loadProfileScaler.to(2)).toEqual(new LoadProfile(getLoadProfileOfTwos(), { year: 2019 }));
+    });
   });
 
   describe('toTotalKwh', () => {
@@ -30,7 +26,7 @@ describe('LoadProfileScaler', () => {
       const totalKwh = 18705;
       const loadProfile = new LoadProfile(
         times(8760, (i) => i % 10),
-        {year: 2019}
+        { year: 2019 },
       );
       const newLoadProfileScaler = new LoadProfileScaler(loadProfile);
 
@@ -42,53 +38,44 @@ describe('LoadProfileScaler', () => {
   describe('toAverageMonthlyBill', () => {
     describe('with a mock', () => {
       it('scales by the scaler that goal-seek finds', () => {
-        // @ts-ignore
-        goalSeek.mockImplementationOnce(() => 200)
+        jest.spyOn(loadProfileScaler, "goalSeek").mockReturnValue(200);
         const scaledLoadProfile = loadProfileScaler.toAverageMonthlyBill(100, e1);
-        expect(scaledLoadProfile).toEqual(
-          new LoadProfile(getLoadProfileOfTwos(), {year: 2019})
-        );
+        expect(scaledLoadProfile).toEqual(new LoadProfile(getLoadProfileOfTwos(), { year: 2019 }));
       });
 
       it('throws the error if goal-seek fails', () => {
-        // @ts-ignore
-        goalSeek.mockImplementationOnce(() => { throw('some goal-seek error'); })
-        
-        expect(
-          () => loadProfileScaler.toAverageMonthlyBill(100, e1)
-        ).toThrow('some goal-seek error');
-      })
+        jest.spyOn(loadProfileScaler, "goalSeek").mockImplementation(() => {
+          throw 'some goal-seek error';
+        });
+        expect(() => loadProfileScaler.toAverageMonthlyBill(100, e1)).toThrow('some goal-seek error');
+      });
 
       it('passes extra parameters to the goal-seek function', () => {
-        // @ts-ignore
-        goalSeek.mockImplementationOnce(() => 200)
         
         const goalSeekParams = {
           maxStep: 55,
           aUselessParam: true,
         };
-
+        
+        const spy = jest.spyOn(loadProfileScaler, "goalSeek").mockReturnValue(200);
         loadProfileScaler.toAverageMonthlyBill(100, e1, goalSeekParams);
-        // @ts-ignore
-        expect(goalSeek).toHaveBeenCalledWith(
-          expect.objectContaining(goalSeekParams)
-        );
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining(goalSeekParams));
       });
     });
   });
 
   describe('toMonthlyKwh', () => {
     it('returns a LoadProfile scaled to the monthly load', () => {
-      const monthlyLoad = times(12, (i) => ((i + 1) * 100));
+      const monthlyLoad = times(12, (i) => (i + 1) * 100);
       const scaledLoadProfile = loadProfileScaler.toMonthlyKwh(monthlyLoad);
 
       scaledLoadProfile.sumByMonth().forEach((monthlyTotal, idx) => {
         expect(monthlyTotal).toBeCloseTo(monthlyLoad[idx]);
-      })
+      });
     });
 
     it('throws an error with an array without 12 elements', () => {
-      const monthlyLoad = times(11, (i) => ((i + 1) * 100));
+      const monthlyLoad = times(11, (i) => (i + 1) * 100);
       expect(() => loadProfileScaler.toMonthlyKwh(monthlyLoad)).toThrowError();
     });
   });

--- a/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
@@ -1,9 +1,9 @@
-import LoadProfileScaler from '../LoadProfileScaler';
-import times from 'lodash/times';
-import LoadProfile from '../LoadProfile';
-import e1 from '../__mocks__/rates/e-1';
-import RateCalculator from '../RateCalculator';
-import type { RateInterface } from '../types';
+import LoadProfileScaler from '../LoadProfileScaler.ts';
+import {times} from 'lodash';
+import LoadProfile from '../LoadProfile.ts';
+import e1 from '../__mocks__/rates/e-1.ts';
+import RateCalculator from '../RateCalculator.ts';
+import type { RateInterface } from '../types/index.ts';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 

--- a/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
+++ b/src/rateEngine/__tests__/LoadProfileScaler.unmocked.test.ts
@@ -1,9 +1,10 @@
 import LoadProfileScaler from '../LoadProfileScaler.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import LoadProfile from '../LoadProfile.ts';
 import e1 from '../__mocks__/rates/e-1.ts';
 import RateCalculator from '../RateCalculator.ts';
 import type { RateInterface } from '../types/index.ts';
+import { jest } from '@jest/globals';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 

--- a/src/rateEngine/__tests__/RateCalculator.test.ts
+++ b/src/rateEngine/__tests__/RateCalculator.test.ts
@@ -1,7 +1,7 @@
-import LoadProfile from '../LoadProfile';
-import RateCalculator from '../RateCalculator';
-import type { RateInterface } from '../types';
-import { BillingCategory } from '../constants';
+import LoadProfile from '../LoadProfile.ts';
+import RateCalculator from '../RateCalculator.ts';
+import type { RateInterface } from '../types/index.ts';
+import { BillingCategory } from '../constants/index.ts';
 
 describe('RateCalculator', () => {
   describe('annualCost', () => {

--- a/src/rateEngine/__tests__/RateElement.HourlyEnergy.test.ts
+++ b/src/rateEngine/__tests__/RateElement.HourlyEnergy.test.ts
@@ -1,7 +1,7 @@
-import PriceProfile from '../PriceProfile';
-import LoadProfile from '../LoadProfile';
-import RateElement from '../RateElement';
-import { RateElementInterface } from '../types';
+import PriceProfile from '../PriceProfile.ts';
+import LoadProfile from '../LoadProfile.ts';
+import RateElement from '../RateElement.ts';
+import { RateElementInterface } from '../types/index.ts';
 
 const YEAR = 2019;
 const priceData = Array(8760).fill(0);

--- a/src/rateEngine/__tests__/RateElement.SurchargeAsPerecent.test.ts
+++ b/src/rateEngine/__tests__/RateElement.SurchargeAsPerecent.test.ts
@@ -1,7 +1,7 @@
-import RateElement from '../RateElement';
-import LoadProfile from '../LoadProfile';
-import type { RateElementInterface } from '../types';
-import { BillingCategory, RateElementClassification } from '../constants';
+import RateElement from '../RateElement.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { RateElementInterface } from '../types/index.ts';
+import { BillingCategory, RateElementClassification } from '../constants/index.ts';
 
 const getLoadProfileOfOnes = () => Array(8760).fill(1);
 

--- a/src/rateEngine/__tests__/loadProfile.test.ts
+++ b/src/rateEngine/__tests__/loadProfile.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../LoadProfile';
-import times from 'lodash/times';
-import LoadProfileScaler from '../LoadProfileScaler';
+import LoadProfile from '../LoadProfile.ts';
+import {times} from 'lodash';
+import LoadProfileScaler from '../LoadProfileScaler.ts';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 const options = {year: 2018};

--- a/src/rateEngine/__tests__/loadProfile.test.ts
+++ b/src/rateEngine/__tests__/loadProfile.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import LoadProfileScaler from '../LoadProfileScaler.ts';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);

--- a/src/rateEngine/__tests__/rates/calcTOU_EV_7_costs.test.ts
+++ b/src/rateEngine/__tests__/rates/calcTOU_EV_7_costs.test.ts
@@ -1,0 +1,29 @@
+import LoadProfile from "../../LoadProfile.ts";
+import RateCalculator from "../../RateCalculator.ts";
+import { RateCalculatorInterface } from "../../types/index.ts";
+import { RATES } from "./data/RATES.ts";
+
+const dailyLoadProfile = [
+  42.0, 42.0, 42.0, 42.0, 42.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 18.0, 18.0, 18.0, 0.0, 0.0, 20.0, 0.0,
+  0.0, 42.0, 42.0, 42.0,
+];
+
+const year = 2025;
+
+describe('RateCalculator', () => {
+  it('.annualCost', () => {
+    expect(dailyLoadProfile.length).toEqual(24);
+
+    const annualLoadProfile = new Array(365).fill(dailyLoadProfile).flat();
+    expect(annualLoadProfile.length).toEqual(8760);
+
+    const loadProfile = new LoadProfile(annualLoadProfile, { year });
+
+    const rate = RATES.TOU_EV_7(year)
+    const rateCalculator = new RateCalculator({ ...rate, loadProfile } as RateCalculatorInterface);
+
+    const annualEnergyCost = rateCalculator.annualCost();
+
+    expect(annualEnergyCost).toBeCloseTo(59783.8244);
+  });
+});

--- a/src/rateEngine/__tests__/rates/calcTOU_EV_8_costs.test.ts
+++ b/src/rateEngine/__tests__/rates/calcTOU_EV_8_costs.test.ts
@@ -1,0 +1,29 @@
+import LoadProfile from '../../LoadProfile.ts';
+import RateCalculator from '../../RateCalculator.ts';
+import { RateCalculatorInterface } from '../../types/index.ts';
+import { RATES } from './data/RATES.ts';
+
+const dailyLoadProfile = [
+  42.0, 42.0, 42.0, 42.0, 42.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 118.0, 118.0, 118.0, 0.0, 0.0, 20.0,
+  0.0, 0.0, 42.0, 42.0, 42.0,
+];
+
+const year = 2025;
+
+describe('RateCalculator', () => {
+  it('.annualCost', () => {
+    expect(dailyLoadProfile.length).toEqual(24);
+
+    const annualLoadProfile = new Array(365).fill(dailyLoadProfile).flat();
+    expect(annualLoadProfile.length).toEqual(8760);
+
+    const loadProfile = new LoadProfile(annualLoadProfile, { year });
+
+    const rate = RATES.TOU_EV_8(year);
+    const rateCalculator = new RateCalculator({ ...rate, loadProfile } as RateCalculatorInterface);
+
+    const annualEnergyCost = rateCalculator.annualCost();
+
+    expect(annualEnergyCost).toBeCloseTo(83270.3837);
+  });
+});

--- a/src/rateEngine/__tests__/rates/calcTOU_EV_9_costs.test.ts
+++ b/src/rateEngine/__tests__/rates/calcTOU_EV_9_costs.test.ts
@@ -1,0 +1,29 @@
+import LoadProfile from "../../LoadProfile.ts";
+import RateCalculator from "../../RateCalculator.ts";
+import { RateCalculatorInterface } from "../../types/index.ts";
+import { RATES } from "./data/RATES.ts";
+
+const dailyLoadProfile = [
+  42.0, 42.0, 42.0, 42.0, 42.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0, 118.0, 118.0, 118.0, 0.0, 0.0, 20.0,
+  0.0, 0.0, 42.0, 42.0, 42.0,
+];
+
+const year = 2025;
+
+describe('RateCalculator', () => {
+  it('.annualCost', () => {
+    expect(dailyLoadProfile.length).toEqual(24);
+
+    const annualLoadProfile = new Array(365).fill(dailyLoadProfile).flat();
+    expect(annualLoadProfile.length).toEqual(8760);
+
+    const loadProfile = new LoadProfile(annualLoadProfile, { year });
+
+    const rate = RATES.TOU_EV_9(year)
+    const rateCalculator = new RateCalculator({ ...rate, loadProfile } as RateCalculatorInterface);
+
+    const annualEnergyCost = rateCalculator.annualCost();
+
+    expect(annualEnergyCost).toBeCloseTo(73835.2953);
+  });
+});

--- a/src/rateEngine/__tests__/rates/data/RATES.ts
+++ b/src/rateEngine/__tests__/rates/data/RATES.ts
@@ -1,0 +1,9 @@
+import TOU_EV_7 from "./TOU_EV_7.ts";
+import TOU_EV_8 from "./TOU_EV_8.ts";
+import TOU_EV_9 from "./TOU_EV_9.ts";
+
+export const RATES = {
+  TOU_EV_7,
+  TOU_EV_8,
+  TOU_EV_9,
+};

--- a/src/rateEngine/__tests__/rates/data/TOU_EV_7.ts
+++ b/src/rateEngine/__tests__/rates/data/TOU_EV_7.ts
@@ -1,0 +1,123 @@
+import { getCommonRateElements } from "./commonRateElements.ts";
+
+// https://www.sce.com/business/rates/electric-car-business-rates/business/rates/electric-car-business-rates
+// https://www.sce.com/sites/default/files/inline-files/TOU-EV-7_8_9%20Rate%20Fact%20Sheet_WCAG%20(2).pdf
+// https://edisonintl.sharepoint.com/teams/Public/TM2/Shared%20Documents/Forms/AllItems.aspx?id=%2Fteams%2FPublic%2FTM2%2FShared%20Documents%2FPublic%2FRegulatory%2FTariff%2DSCE%20Tariff%20Books%2FElectric%2FSchedules%2FGeneral%20Service%20%26%20Industrial%20Rates&p=true&ga=1
+//
+// Service under this Schedule will be supplied at one standard voltage.
+const touEV7 = (year: number) => {
+  return {
+    name: "TOU-EV-7",
+    title: "20kW or Less.",
+    code: "TOU_EV_7",
+    helpText:
+      "Applicable to businesses that separately meter the charging of their electric vehicles with charging demands of 20 kilowatts (kW) or less.",
+
+    minKw: 0,
+    maxKw: 20,
+
+    rateElements: getCommonRateElements("TOU_EV_7", years, year),
+  };
+};
+
+// * NOTE: EV-7 rates are the same for each year and have 0 demand charges
+const years = {
+  2024: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 0,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2025: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 0,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2026: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 3.25832,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2027: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 6.51663,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2028: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 9.77495,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2029: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 13.03326,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2030: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 16.29158,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+  2031: {
+    fixed_perday: 0,
+    fixed_permonth: 8.76,
+    demand_charge: 19.54989,
+    energy_summer_on: 0.6609,
+    energy_summer_mid: 0.40084,
+    energy_summer_off: 0.25369,
+    energy_winter_mid: 0.47493,
+    energy_winter_off: 0.27445,
+    energy_winter_superoff: 0.14253,
+    energy_threephaseserivce: 0,
+  },
+};
+
+export default touEV7;

--- a/src/rateEngine/__tests__/rates/data/TOU_EV_8.ts
+++ b/src/rateEngine/__tests__/rates/data/TOU_EV_8.ts
@@ -1,0 +1,118 @@
+import { getCommonRateElements } from "./commonRateElements.ts";
+
+// Voltage: Service under this Schedule will be supplied at one standard voltage.
+const touEV8 = (year: number) => {
+  return {
+    name: "TOU-EV-8",
+    code: "TOU_EV_8",
+    helpText:
+      "Applicable to businesses that separately meter the charging of their electric vehicles with charging demands above 20 kilowatts (kW) and less than 500kW.",
+    title: "Above 20kW and up to 500kW.",
+
+    minKw: 20,
+    maxKw: 500,
+
+    rateElements: getCommonRateElements("TOU_EV_8", years, year),
+  };
+};
+
+const years = {
+  2024: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 0,
+    energy_summer_on: 0.69592,
+    energy_summer_mid: 0.39786,
+    energy_summer_off: 0.23294,
+    energy_winter_mid: 0.44997,
+    energy_winter_off: 0.24897,
+    energy_winter_superoff: 0.12406,
+    energy_threephaseserivce: 0,
+  },
+  2025: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 0,
+    energy_summer_on: 0.69592,
+    energy_summer_mid: 0.39786,
+    energy_summer_off: 0.23294,
+    energy_winter_mid: 0.44997,
+    energy_winter_off: 0.24897,
+    energy_winter_superoff: 0.12406,
+    energy_threephaseserivce: 0,
+  },
+  2026: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 3.25832,
+    energy_summer_on: 0.60946,
+    energy_summer_mid: 0.3114,
+    energy_summer_off: 0.22986,
+    energy_winter_mid: 0.3635,
+    energy_winter_off: 0.24589,
+    energy_winter_superoff: 0.15939,
+    energy_threephaseserivce: 0,
+  },
+  2027: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 6.51663,
+    energy_summer_on: 0.59642,
+    energy_summer_mid: 0.29836,
+    energy_summer_off: 0.21682,
+    energy_winter_mid: 0.35046,
+    energy_winter_off: 0.23284,
+    energy_winter_superoff: 0.14635,
+    energy_threephaseserivce: 0,
+  },
+  2028: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 9.77495,
+    energy_summer_on: 0.58337,
+    energy_summer_mid: 0.28531,
+    energy_summer_off: 0.20377,
+    energy_winter_mid: 0.33742,
+    energy_winter_off: 0.2198,
+    energy_winter_superoff: 0.1333,
+    energy_threephaseserivce: 0,
+  },
+  2029: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 13.03326,
+    energy_summer_on: 0.57033,
+    energy_summer_mid: 0.27227,
+    energy_summer_off: 0.19073,
+    energy_winter_mid: 0.32438,
+    energy_winter_off: 0.20676,
+    energy_winter_superoff: 0.12026,
+    energy_threephaseserivce: 0,
+  },
+  2030: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 16.29158,
+    energy_summer_on: 0.55729,
+    energy_summer_mid: 0.25923,
+    energy_summer_off: 0.17769,
+    energy_winter_mid: 0.31133,
+    energy_winter_off: 0.19371,
+    energy_winter_superoff: 0.10722,
+    energy_threephaseserivce: 0,
+  },
+  2031: {
+    fixed_perday: 0,
+    fixed_permonth: 228.13,
+    demand_charge: 19.54989,
+    energy_summer_on: 0.54425,
+    energy_summer_mid: 0.24618,
+    energy_summer_off: 0.16465,
+    energy_winter_mid: 0.29829,
+    energy_winter_off: 0.18067,
+    energy_winter_superoff: 0.09417,
+    energy_threephaseserivce: 0,
+  },
+};
+
+export default touEV8;

--- a/src/rateEngine/__tests__/rates/data/TOU_EV_9.ts
+++ b/src/rateEngine/__tests__/rates/data/TOU_EV_9.ts
@@ -1,0 +1,102 @@
+import { getCommonRateElements } from "./commonRateElements.ts";
+
+// Assume Secondary <2kV voltage for this application
+const touEV9 = (year: number) => {
+  return {
+    name: "TOU-EV-9",
+    title: "Above 500kW.",
+    code: "TOU_EV_9",
+    helpText:
+      "Applicable to businesses that separately meter the charging of their electric vehicles with charging demands exceeding 500 kW.",
+
+    minKw: 500,
+    maxKw: Infinity,
+
+    rateElements: getCommonRateElements("TOU_EV_9", years, year),
+  };
+};
+
+const years = {
+  2024: {
+    fixed_permonth: 434.84,
+    demand_charge: 0,
+    energy_summer_on: 0.55751,
+    energy_summer_mid: 0.34658,
+    energy_summer_off: 0.19465,
+    energy_winter_mid: 0.39583,
+    energy_winter_off: 0.20708,
+    energy_winter_superoff: 0.11499,
+  },
+  2025: {
+    fixed_permonth: 434.84,
+    demand_charge: 0,
+    energy_summer_on: 0.55751,
+    energy_summer_mid: 0.34658,
+    energy_summer_off: 0.19465,
+    energy_winter_mid: 0.39583,
+    energy_winter_off: 0.20708,
+    energy_winter_superoff: 0.11499,
+  },
+  2026: {
+    fixed_permonth: 434.84,
+    demand_charge: 3.69874720819057,
+    energy_summer_on: 0.487779625615833,
+    energy_summer_mid: 0.276851997171223,
+    energy_summer_off: 0.194830335019026,
+    energy_winter_mid: 0.326103498899183,
+    energy_winter_off: 0.207264543305111,
+    energy_winter_superoff: 0.137250773509474,
+  },
+  2027: {
+    fixed_permonth: 434.84,
+    demand_charge: 7.39749441638113,
+    energy_summer_on: 0.478315098692097,
+    energy_summer_mid: 0.267387470247486,
+    energy_summer_off: 0.185365808095289,
+    energy_winter_mid: 0.316638971975447,
+    energy_winter_off: 0.197800016381374,
+    energy_winter_superoff: 0.127786246585737,
+  },
+  2028: {
+    fixed_permonth: 434.84,
+    demand_charge: 11.0962416245717,
+    energy_summer_on: 0.46885057176836,
+    energy_summer_mid: 0.257922943323749,
+    energy_summer_off: 0.175901281171553,
+    energy_winter_mid: 0.30717444505171,
+    energy_winter_off: 0.188335489457638,
+    energy_winter_superoff: 0.118321719662,
+  },
+  2029: {
+    fixed_permonth: 434.84,
+    demand_charge: 14.7949888327623,
+    energy_summer_on: 0.459386044844624,
+    energy_summer_mid: 0.248458416400013,
+    energy_summer_off: 0.166436754247816,
+    energy_winter_mid: 0.297709918127974,
+    energy_winter_off: 0.178870962533901,
+    energy_winter_superoff: 0.108857192738264,
+  },
+  2030: {
+    fixed_permonth: 434.84,
+    demand_charge: 18.4937360409528,
+    energy_summer_on: 0.449921517920887,
+    energy_summer_mid: 0.238993889476276,
+    energy_summer_off: 0.156972227324079,
+    energy_winter_mid: 0.288245391204237,
+    energy_winter_off: 0.169406435610164,
+    energy_winter_superoff: 0.0993926658145272,
+  },
+  2031: {
+    fixed_permonth: 434.84,
+    demand_charge: 22.1924832491434,
+    energy_summer_on: 0.44045699099715,
+    energy_summer_mid: 0.229529362552539,
+    energy_summer_off: 0.147507700400343,
+    energy_winter_mid: 0.2787808642805,
+    energy_winter_off: 0.159941908686428,
+    energy_winter_superoff: 0.0899281388907905,
+  },
+};
+
+export default touEV9;

--- a/src/rateEngine/__tests__/rates/data/commonRateElements.ts
+++ b/src/rateEngine/__tests__/rates/data/commonRateElements.ts
@@ -1,0 +1,109 @@
+import { RateElementClassification } from "../../../constants/index.ts";
+import { RateElementInterface } from "../../../types/index.ts";
+import { WEEKDAYS, WEEKEND, ALL_DAYS_OF_WEEK, SUMMER, WINTER } from "../times/index.ts";
+
+
+const cachedRateElements = {} as Record<string, Record<number, any[]>>;
+
+export const getCommonRateElements = (
+  rateName: string,
+  years: Record<number, Record<string, number>>,
+  year: number,
+): any[] => {
+  if (year > 2031) {
+    return [];
+  }
+
+  if (cachedRateElements?.[rateName]?.[year]) {
+    return cachedRateElements[rateName][year];
+  }
+
+  const rate = {
+    [year]: [
+      {
+        name: "Demand Charge ($/kW)",
+        rateElementType: "MonthlyDemand" as RateElementInterface["rateElementType"],
+        classification: RateElementClassification.DEMAND,
+        rateComponents: [
+          {
+            name: "Monthly Demand Charge",
+            charge: years[year].demand_charge,
+          },
+        ],
+      },
+      {
+        name: "Customer Charge ($/Month)",
+        rateElementType: "FixedPerMonth",
+        classification: RateElementClassification.FIXED,
+        rateComponents: [
+          {
+            name: "Monthly Customer Charge",
+            charge: years[year].fixed_permonth,
+          },
+        ],
+      },
+      {
+        name: "Energy Charge ($/kWh)",
+        rateElementType: "EnergyTimeOfUse" as RateElementInterface["rateElementType"],
+        classification: RateElementClassification.ENERGY,
+        rateComponents: [
+          {
+            charge: years[year].energy_summer_on,
+            months: SUMMER,
+            daysOfWeek: WEEKDAYS,
+            exceptForDays: [],
+            hourStarts: [16, 17, 18, 19, 20], // 4-9 PM
+            name: "Summer Peak",
+          },
+          {
+            charge: years[year].energy_summer_mid,
+            months: SUMMER,
+            daysOfWeek: WEEKEND,
+            exceptForDays: [],
+            hourStarts: [16, 17, 18, 19, 20], // 4-9 PM
+            name: "Summer Mid-Peak",
+          },
+          {
+            charge: years[year].energy_summer_off,
+            months: SUMMER,
+            daysOfWeek: ALL_DAYS_OF_WEEK,
+            exceptForDays: [],
+            hourStarts: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 21, 22, 23],
+            name: "Summer Off-Peak",
+          },
+          {
+            charge: years[year].energy_winter_mid,
+            months: WINTER,
+            daysOfWeek: ALL_DAYS_OF_WEEK,
+            exceptForDays: [],
+            hourStarts: [16, 17, 18, 19, 20], // 4-9 PM
+            name: "Winter Mid-Peak",
+          },
+          {
+            charge: years[year].energy_winter_off,
+            months: WINTER,
+            daysOfWeek: ALL_DAYS_OF_WEEK,
+            exceptForDays: [],
+            hourStarts: [0, 1, 2, 3, 4, 5, 6, 7, 21, 22, 23],
+            name: "Winter Off-Peak",
+          },
+          {
+            charge: years[year].energy_winter_superoff,
+            months: WINTER,
+            daysOfWeek: ALL_DAYS_OF_WEEK,
+            exceptForDays: [],
+            hourStarts: [8, 9, 10, 11, 12, 13, 14, 15], // 8AM - 4PM
+            name: "Winter Super Off-Peak",
+          },
+        ],
+      },
+    ],
+  } as Record<string, Record<number, any>>;
+
+  cachedRateElements[rateName] = {
+    ...cachedRateElements[rateName],
+    ...rate,
+  };
+
+  return rate[year as number] as any[];
+};

--- a/src/rateEngine/__tests__/rates/data/index.ts
+++ b/src/rateEngine/__tests__/rates/data/index.ts
@@ -1,0 +1,31 @@
+import LoadProfile from "../../../LoadProfile.ts";
+import { RATES } from "./RATES.ts";
+
+const getRates = ({ year }: { year: number }) => [RATES.TOU_EV_7(year), RATES.TOU_EV_8(year), RATES.TOU_EV_9(year)];
+
+// Returns false if a rate's max kW is met for 3 consecutive months
+// according to https://docs.google.com/spreadsheets/d/194i_6H7-ckuB6uCUK5QGjWmVSG0ebVz-QK9RyI8J-sQ/edit#gid=309346728
+const isRateApplicable = (
+  rate: Record<string, any>, // TODO: Replace with rate type
+  loadProfile: LoadProfile,
+  { ignoreMaxKw }: { ignoreMaxKw: boolean },
+) => {
+  const { maxKw } = rate;
+  if (ignoreMaxKw || maxKw === undefined) return true;
+
+  const maxByMonth = loadProfile.maxByMonth();
+  const exceedsMaxForThreeMonths = maxByMonth.some((month, idx, arr) => {
+    // wrap around to beginning of the year for November/December
+    const nextMonth = idx + 1 < arr.length ? arr[idx + 1] : arr[0];
+    const monthAfterNext = idx + 2 < arr.length ? arr[idx + 2] : idx + 2 === arr.length ? arr[0] : arr[1];
+    return month > maxKw && nextMonth > maxKw && monthAfterNext > maxKw;
+  });
+
+  return !exceedsMaxForThreeMonths;
+};
+
+export const getApplicableRates = (
+  loadProfile: LoadProfile,
+  { year, ignoreMaxKw }: { year: number; ignoreMaxKw: boolean },
+) => getRates({ year }).filter((rate) => isRateApplicable(rate, loadProfile, { ignoreMaxKw }));
+

--- a/src/rateEngine/__tests__/rates/times/index.ts
+++ b/src/rateEngine/__tests__/rates/times/index.ts
@@ -1,0 +1,80 @@
+export enum EDayOfWeek {
+    SUNDAY = 0,
+    MONDAY = 1,
+    TUESDAY = 2,
+    WEDNESDAY = 3,
+    THURSDAY = 4,
+    FRIDAY = 5,
+    SATURDAY = 6,
+  }
+  
+  export const WEEKDAYS = [
+    EDayOfWeek.MONDAY,
+    EDayOfWeek.TUESDAY,
+    EDayOfWeek.WEDNESDAY,
+    EDayOfWeek.THURSDAY,
+    EDayOfWeek.FRIDAY,
+  ];
+  
+  export const WEEKEND = [EDayOfWeek.SATURDAY, EDayOfWeek.SUNDAY];
+  
+  export const ALL_DAYS_OF_WEEK = [
+    EDayOfWeek.SUNDAY,
+    EDayOfWeek.MONDAY,
+    EDayOfWeek.TUESDAY,
+    EDayOfWeek.WEDNESDAY,
+    EDayOfWeek.THURSDAY,
+    EDayOfWeek.FRIDAY,
+    EDayOfWeek.SATURDAY,
+  ];
+  
+  export type TRateYear = 2024 | 2025 | 2026 | 2027 | 2028 | 2029 | 2030 | 2031;
+  
+  export const MIN_RATE_YEAR = new Date().getFullYear() as TRateYear;
+  export const MAX_RATE_YEAR = 2031 as TRateYear;
+  export const ALL_RATE_YEARS = [2025, 2026, 2027, 2028, 2029, 2030, 2031] as TRateYear[];
+  
+
+  export enum EMonthsOfYear {
+    JANUARY = 0, // dayjs starts at 0
+    FEBRUARY = 1,
+    MARCH = 2,
+    APRIL = 3,
+    MAY = 4,
+    JUNE = 5,
+    JULY = 6,
+    AUGUST = 7,
+    SEPTEMBER = 8,
+    OCTOBER = 9,
+    NOVEMBER = 10,
+    DECEMBER = 11,
+  }
+  
+  export const SUMMER = [EMonthsOfYear.JUNE, EMonthsOfYear.JULY, EMonthsOfYear.AUGUST, EMonthsOfYear.SEPTEMBER];
+  
+  export const WINTER = [
+    EMonthsOfYear.JANUARY,
+    EMonthsOfYear.FEBRUARY,
+    EMonthsOfYear.MARCH,
+    EMonthsOfYear.APRIL,
+    EMonthsOfYear.MAY,
+    EMonthsOfYear.OCTOBER,
+    EMonthsOfYear.NOVEMBER,
+    EMonthsOfYear.DECEMBER,
+  ];
+  
+  export const ALL_MONTHS_OF_YEAR = [
+    EMonthsOfYear.JANUARY,
+    EMonthsOfYear.FEBRUARY,
+    EMonthsOfYear.MARCH,
+    EMonthsOfYear.APRIL,
+    EMonthsOfYear.MAY,
+    EMonthsOfYear.JUNE,
+    EMonthsOfYear.JULY,
+    EMonthsOfYear.AUGUST,
+    EMonthsOfYear.SEPTEMBER,
+    EMonthsOfYear.OCTOBER,
+    EMonthsOfYear.NOVEMBER,
+    EMonthsOfYear.DECEMBER,
+  ];
+  

--- a/src/rateEngine/billingDeterminants/AnnualDemand.ts
+++ b/src/rateEngine/billingDeterminants/AnnualDemand.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash';
+import { times } from "lodash-es";
 import BillingDeterminants from './_BillingDeterminants.ts';
 import LoadProfile from '../LoadProfile.ts';
 import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
@@ -6,7 +6,7 @@ import { RateElementClassification, BillingDeterminantsUnits } from '../constant
 class AnnualDemand extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Annual Demand.ts';
+  rateElementType = 'Annual Demand';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/AnnualDemand.ts
+++ b/src/rateEngine/billingDeterminants/AnnualDemand.ts
@@ -1,12 +1,12 @@
-import BillingDeterminants from './_BillingDeterminants';
-import LoadProfile from '../LoadProfile';
-import times from 'lodash/times';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
+import { times } from 'lodash';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import LoadProfile from '../LoadProfile.ts';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
 
 class AnnualDemand extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Annual Demand';
+  rateElementType = 'Annual Demand.ts';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/BlockedTiersInDays.ts
+++ b/src/rateEngine/billingDeterminants/BlockedTiersInDays.ts
@@ -1,13 +1,10 @@
-import groupBy from 'lodash/groupBy';
-import sumBy from 'lodash/sumBy';
-import times from 'lodash/times';
-import LoadProfile from '../LoadProfile';
-import BillingDeterminants from './_BillingDeterminants';
-import {  } from '../LoadProfileFilter';
-import { daysPerMonth } from '../utils/assumptions';
-import convertInfinities from '../utils/convertInfinities';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types';
+import { groupBy, sumBy, times } from 'lodash';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';
+import { daysPerMonth } from '../utils/assumptions.ts';
+import convertInfinities from '../utils/convertInfinities.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
 
 class BlockedTiersInDays extends BillingDeterminants {
   private _loadProfile: LoadProfile;

--- a/src/rateEngine/billingDeterminants/BlockedTiersInDays.ts
+++ b/src/rateEngine/billingDeterminants/BlockedTiersInDays.ts
@@ -1,4 +1,4 @@
-import { groupBy, sumBy, times } from 'lodash';
+import { groupBy, sumBy, times } from "lodash-es";
 import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 import LoadProfile from '../LoadProfile.ts';
 import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';

--- a/src/rateEngine/billingDeterminants/BlockedTiersInMonths.ts
+++ b/src/rateEngine/billingDeterminants/BlockedTiersInMonths.ts
@@ -1,4 +1,4 @@
-import { groupBy, sumBy, times } from 'lodash';
+import { groupBy, sumBy, times } from "lodash-es";
 import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 import LoadProfile from '../LoadProfile.ts';
 import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';

--- a/src/rateEngine/billingDeterminants/BlockedTiersInMonths.ts
+++ b/src/rateEngine/billingDeterminants/BlockedTiersInMonths.ts
@@ -1,11 +1,9 @@
-import groupBy from 'lodash/groupBy';
-import sumBy from 'lodash/sumBy';
-import times from 'lodash/times';
-import LoadProfile from '../LoadProfile';
-import BillingDeterminants from './_BillingDeterminants';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types';
-import convertInfinities from '../utils/convertInfinities';
+import { groupBy, sumBy, times } from 'lodash';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';
+import convertInfinities from '../utils/convertInfinities.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
 
 class BlockedTiersInMonths extends BillingDeterminants {
   private _loadProfile: LoadProfile;

--- a/src/rateEngine/billingDeterminants/DemandPerDay.ts
+++ b/src/rateEngine/billingDeterminants/DemandPerDay.ts
@@ -1,4 +1,4 @@
-import { groupBy, sum, times } from 'lodash';
+import { groupBy, sum, times } from "lodash-es";
 import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 import LoadProfile from '../LoadProfile.ts';
 import type { DemandPerDayArgs, LoadProfileFilterArgs } from '../types/index.ts';
@@ -8,7 +8,7 @@ class DemandPerDay extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Demand Per Day.ts';
+  rateElementType = 'Demand Per Day';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/DemandPerDay.ts
+++ b/src/rateEngine/billingDeterminants/DemandPerDay.ts
@@ -1,16 +1,14 @@
-import LoadProfile from '../LoadProfile';
-import BillingDeterminants from './_BillingDeterminants';
-import times from 'lodash/times';
-import groupBy from 'lodash/groupBy';
-import sum from 'lodash/sum';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import type { DemandPerDayArgs, LoadProfileFilterArgs } from '../types';
+import { groupBy, sum, times } from 'lodash';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { DemandPerDayArgs, LoadProfileFilterArgs } from '../types/index.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
 
 class DemandPerDay extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Demand Per Day';
+  rateElementType = 'Demand Per Day.ts';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/DemandTiersInMonths.ts
+++ b/src/rateEngine/billingDeterminants/DemandTiersInMonths.ts
@@ -1,4 +1,4 @@
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 import { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';
 import LoadProfile from '../LoadProfile.ts';

--- a/src/rateEngine/billingDeterminants/DemandTiersInMonths.ts
+++ b/src/rateEngine/billingDeterminants/DemandTiersInMonths.ts
@@ -1,9 +1,9 @@
-import times from 'lodash/times';
-import { BillingDeterminantsUnits, RateElementClassification } from '../constants';
-import LoadProfile from '../LoadProfile';
-import { BlockedTiersArgs, LoadProfileFilterArgs } from '../types';
-import convertInfinities from '../utils/convertInfinities';
-import BillingDeterminants from './_BillingDeterminants';
+import {times} from 'lodash';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import { BlockedTiersArgs, LoadProfileFilterArgs } from '../types/index.ts';
+import LoadProfile from '../LoadProfile.ts';
+import convertInfinities from '../utils/convertInfinities.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
 
 class DemandTiersInMonths extends BillingDeterminants {
   private _loadProfile: LoadProfile;

--- a/src/rateEngine/billingDeterminants/DemandTimeOfUse.ts
+++ b/src/rateEngine/billingDeterminants/DemandTimeOfUse.ts
@@ -7,7 +7,7 @@ class DemandTimeOfUse extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Time Of Use.ts';
+  rateElementType = 'Time Of Use';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/DemandTimeOfUse.ts
+++ b/src/rateEngine/billingDeterminants/DemandTimeOfUse.ts
@@ -1,13 +1,13 @@
-import LoadProfile from '../LoadProfile';
-import BillingDeterminants from './_BillingDeterminants';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import type { DemandTimeOfUseArgs, LoadProfileFilterArgs } from '../types';
+import LoadProfile from '../LoadProfile.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
+import type { DemandTimeOfUseArgs, LoadProfileFilterArgs } from '../types/index.ts';
 
 class DemandTimeOfUse extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Time Of Use';
+  rateElementType = 'Time Of Use.ts';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/EnergyTimeOfUse.ts
+++ b/src/rateEngine/billingDeterminants/EnergyTimeOfUse.ts
@@ -1,13 +1,13 @@
-import BillingDeterminants from './_BillingDeterminants';
-import LoadProfile from '../LoadProfile';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import type { EnergyTimeOfUseArgs, LoadProfileFilterArgs } from '../types';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import LoadProfile from '../LoadProfile.ts';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
+import type { EnergyTimeOfUseArgs, LoadProfileFilterArgs } from '../types/index.ts';
 
 class EnergyTimeOfUse extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Time Of Use';
+  rateElementType = 'Time Of Use.ts';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/EnergyTimeOfUse.ts
+++ b/src/rateEngine/billingDeterminants/EnergyTimeOfUse.ts
@@ -7,7 +7,7 @@ class EnergyTimeOfUse extends BillingDeterminants {
   private _filters: LoadProfileFilterArgs;
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Time Of Use.ts';
+  rateElementType = 'Time Of Use';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/FixedPerDay.ts
+++ b/src/rateEngine/billingDeterminants/FixedPerDay.ts
@@ -1,9 +1,9 @@
-import BillingDeterminants from './_BillingDeterminants';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
-import { daysPerMonth } from '../utils/assumptions';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import { daysPerMonth } from '../utils/assumptions.ts';
 
 class FixedPerDay extends BillingDeterminants {
-  rateElementType = 'Fixed Per Day';
+  rateElementType = 'Fixed Per Day.ts';
   rateElementClassification = RateElementClassification.FIXED;
   units = BillingDeterminantsUnits.DAYS;
 

--- a/src/rateEngine/billingDeterminants/FixedPerDay.ts
+++ b/src/rateEngine/billingDeterminants/FixedPerDay.ts
@@ -3,7 +3,7 @@ import BillingDeterminants from './_BillingDeterminants.ts';
 import { daysPerMonth } from '../utils/assumptions.ts';
 
 class FixedPerDay extends BillingDeterminants {
-  rateElementType = 'Fixed Per Day.ts';
+  rateElementType = 'Fixed Per Day';
   rateElementClassification = RateElementClassification.FIXED;
   units = BillingDeterminantsUnits.DAYS;
 

--- a/src/rateEngine/billingDeterminants/FixedPerMonth.ts
+++ b/src/rateEngine/billingDeterminants/FixedPerMonth.ts
@@ -1,6 +1,6 @@
-import BillingDeterminants from './_BillingDeterminants';
-import times from 'lodash/times';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import {times} from 'lodash';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
 
 const MONTHS_PER_YEAR = 12;
 

--- a/src/rateEngine/billingDeterminants/FixedPerMonth.ts
+++ b/src/rateEngine/billingDeterminants/FixedPerMonth.ts
@@ -1,5 +1,5 @@
 import BillingDeterminants from './_BillingDeterminants.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
 
 const MONTHS_PER_YEAR = 12;

--- a/src/rateEngine/billingDeterminants/HourlyEnergy.ts
+++ b/src/rateEngine/billingDeterminants/HourlyEnergy.ts
@@ -1,15 +1,15 @@
-import BillingDeterminants from './_BillingDeterminants';
-import expandedDates from '../utils/expandedDates';
-import LoadProfile from '../LoadProfile';
-import { BillingDeterminantsUnits, RateElementClassification } from '../constants';
-import type { HourlyEnergyArgs, ExpandedDate } from '../types';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import expandedDates from '../utils/expandedDates.ts';
+import LoadProfile from '../LoadProfile.ts';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import type { HourlyEnergyArgs, ExpandedDate } from '../types/index.ts';
 
 class HourlyEnergy extends BillingDeterminants {
   private _load: number;
   private _hourOfYear: number;
   private _year: number;
 
-  rateElementType = 'Hourly Energy';
+  rateElementType = 'Hourly Energy.ts';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/HourlyEnergy.ts
+++ b/src/rateEngine/billingDeterminants/HourlyEnergy.ts
@@ -9,7 +9,7 @@ class HourlyEnergy extends BillingDeterminants {
   private _hourOfYear: number;
   private _year: number;
 
-  rateElementType = 'Hourly Energy.ts';
+  rateElementType = 'Hourly Energy';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/MonthlyDemand.ts
+++ b/src/rateEngine/billingDeterminants/MonthlyDemand.ts
@@ -5,7 +5,7 @@ import { RateElementClassification, BillingDeterminantsUnits } from '../constant
 class MonthlyDemand extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Monthly Demand.ts';
+  rateElementType = 'Monthly Demand';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/MonthlyDemand.ts
+++ b/src/rateEngine/billingDeterminants/MonthlyDemand.ts
@@ -1,11 +1,11 @@
-import BillingDeterminants from './_BillingDeterminants';
-import LoadProfile from '../LoadProfile';
-import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import LoadProfile from '../LoadProfile.ts';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants/index.ts';
 
 class MonthlyDemand extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Monthly Demand';
+  rateElementType = 'Monthly Demand.ts';
   rateElementClassification = RateElementClassification.DEMAND;
   units = BillingDeterminantsUnits.KW;
 

--- a/src/rateEngine/billingDeterminants/MonthlyEnergy.ts
+++ b/src/rateEngine/billingDeterminants/MonthlyEnergy.ts
@@ -5,7 +5,7 @@ import { BillingDeterminantsUnits, RateElementClassification } from '../constant
 class MonthlyEnergy extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Monthly Energy.ts';
+  rateElementType = 'Monthly Energy';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/MonthlyEnergy.ts
+++ b/src/rateEngine/billingDeterminants/MonthlyEnergy.ts
@@ -1,11 +1,11 @@
-import BillingDeterminants from './_BillingDeterminants';
-import LoadProfile from '../LoadProfile';
-import { BillingDeterminantsUnits, RateElementClassification } from '../constants';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import LoadProfile from '../LoadProfile.ts';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 
 class MonthlyEnergy extends BillingDeterminants {
   private _loadProfile: LoadProfile;
 
-  rateElementType = 'Monthly Energy';
+  rateElementType = 'Monthly Energy.ts';
   rateElementClassification = RateElementClassification.ENERGY;
   units = BillingDeterminantsUnits.KWH;
 

--- a/src/rateEngine/billingDeterminants/SurchargeAsPercent.ts
+++ b/src/rateEngine/billingDeterminants/SurchargeAsPercent.ts
@@ -6,7 +6,7 @@ import type { SurchargeAsPercentArgs } from '../types/index.ts';
 class SurchargeAsPercent extends BillingDeterminants {
   private _rateElement: RateElement;
 
-  rateElementType = 'Surcharge.ts';
+  rateElementType = 'Surcharge';
   rateElementClassification = RateElementClassification.SURCHARGE;
   units = BillingDeterminantsUnits.DOLLARS;
 

--- a/src/rateEngine/billingDeterminants/SurchargeAsPercent.ts
+++ b/src/rateEngine/billingDeterminants/SurchargeAsPercent.ts
@@ -1,12 +1,12 @@
-import RateElement from '../RateElement';
-import { BillingDeterminantsUnits, RateElementClassification } from '../constants';
-import type { SurchargeAsPercentArgs } from '../types';
-import BillingDeterminants from './_BillingDeterminants';
+import RateElement from '../RateElement.ts';
+import BillingDeterminants from './_BillingDeterminants.ts';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
+import type { SurchargeAsPercentArgs } from '../types/index.ts';
 
 class SurchargeAsPercent extends BillingDeterminants {
   private _rateElement: RateElement;
 
-  rateElementType = 'Surcharge';
+  rateElementType = 'Surcharge.ts';
   rateElementClassification = RateElementClassification.SURCHARGE;
   units = BillingDeterminantsUnits.DOLLARS;
 

--- a/src/rateEngine/billingDeterminants/_BillingDeterminants.ts
+++ b/src/rateEngine/billingDeterminants/_BillingDeterminants.ts
@@ -1,5 +1,5 @@
-import lodashMean from 'lodash/mean';
-import { BillingDeterminantsUnits, RateElementClassification } from '../constants';
+import {mean} from 'lodash';
+import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 
 abstract class BillingDeterminants {
   abstract rateElementType: string;
@@ -8,7 +8,7 @@ abstract class BillingDeterminants {
   abstract calculate(): Array<number>;
 
   mean(): number {
-    return lodashMean(this.calculate());
+    return mean(this.calculate());
   }
 
   all(): Array<number> {

--- a/src/rateEngine/billingDeterminants/_BillingDeterminants.ts
+++ b/src/rateEngine/billingDeterminants/_BillingDeterminants.ts
@@ -1,4 +1,4 @@
-import {mean} from 'lodash';
+import {mean} from "lodash-es";
 import { BillingDeterminantsUnits, RateElementClassification } from '../constants/index.ts';
 
 abstract class BillingDeterminants {

--- a/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import AnnualDemand from '../AnnualDemand';
+import {times} from 'lodash';
+import LoadProfile from '../../LoadProfile.ts';
+import AnnualDemand from '../AnnualDemand.ts';
 
 const getLoadProfileOfOneThroughTen = () => times(8760, (num) => (num % 10) + 1);
 const getLoadProfileWithOneNonZero = () => times(8760, (i) => (i === 1234 ? 100 : 0));

--- a/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/AnnualDemand.test.ts
@@ -1,4 +1,4 @@
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import LoadProfile from '../../LoadProfile.ts';
 import AnnualDemand from '../AnnualDemand.ts';
 

--- a/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInDays.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInDays.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import BlockedTiersInDays from '../BlockedTiersInDays.ts';
 
 // For reference: the number of hours in each month:

--- a/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInDays.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInDays.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import BlockedTiersInDays from '../BlockedTiersInDays';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import BlockedTiersInDays from '../BlockedTiersInDays.ts';
 
 // For reference: the number of hours in each month:
 // [ 744, 672, 743, 720, 744, 720, 744, 744, 720, 744, 721, 744 ]

--- a/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInMonths.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInMonths.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import BlockedTiersInMonths from '../BlockedTiersInMonths';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import BlockedTiersInMonths from '../BlockedTiersInMonths.ts';
 
 // For reference: the number of hours in each month:
 // [ 744, 672, 743, 720, 744, 720, 744, 744, 720, 744, 721, 744 ]

--- a/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInMonths.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/BlockedTiersInMonths.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import BlockedTiersInMonths from '../BlockedTiersInMonths.ts';
 
 // For reference: the number of hours in each month:

--- a/src/rateEngine/billingDeterminants/__tests__/DemandPerDay.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandPerDay.test.ts
@@ -1,9 +1,9 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import DemandPerDay from '../DemandPerDay';
-import data from './DemandPerDayData';
-import { daysPerMonth } from '../../utils/assumptions';
-import type { DemandPerDayArgs } from '../../types';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import DemandPerDay from '../DemandPerDay.ts';
+import data from './DemandPerDayData.ts';
+import { daysPerMonth } from '../../utils/assumptions.ts';
+import type { DemandPerDayArgs } from '../../types/index.ts';
 
 
 interface TestData {

--- a/src/rateEngine/billingDeterminants/__tests__/DemandPerDay.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandPerDay.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import DemandPerDay from '../DemandPerDay.ts';
 import data from './DemandPerDayData.ts';
 import { daysPerMonth } from '../../utils/assumptions.ts';

--- a/src/rateEngine/billingDeterminants/__tests__/DemandTiersInMonths.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandTiersInMonths.test.ts
@@ -1,5 +1,5 @@
-import LoadProfile from '../../LoadProfile';
-import DemandTiersInMonths from '../DemandTiersInMonths';
+import LoadProfile from '../../LoadProfile.ts';
+import DemandTiersInMonths from '../DemandTiersInMonths.ts';
 
 const KWS_GREATER_THAN_ONE = [2,5,20,15,12,17,4,8,30,10,4,15];
 

--- a/src/rateEngine/billingDeterminants/__tests__/DemandTimeOfUse.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandTimeOfUse.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import DemandTimeOfUse from '../DemandTimeOfUse.ts';
 import data from './DemandTimeOfUseData.ts';
 import type { DemandTimeOfUseArgs } from '../../types/index.ts';

--- a/src/rateEngine/billingDeterminants/__tests__/DemandTimeOfUse.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandTimeOfUse.test.ts
@@ -1,8 +1,8 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import DemandTimeOfUse from '../DemandTimeOfUse';
-import data from './DemandTimeOfUseData';
-import type { DemandTimeOfUseArgs } from '../../types';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import DemandTimeOfUse from '../DemandTimeOfUse.ts';
+import data from './DemandTimeOfUseData.ts';
+import type { DemandTimeOfUseArgs } from '../../types/index.ts';
 
 interface TestData {
   name: string;

--- a/src/rateEngine/billingDeterminants/__tests__/EnergyTimeOfUse.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/EnergyTimeOfUse.test.ts
@@ -1,8 +1,8 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import EnergyTimeOfUse from '../EnergyTimeOfUse';
-import data from './EnergyTimeOfUseData';
-import type { EnergyTimeOfUseArgs } from '../../types';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import EnergyTimeOfUse from '../EnergyTimeOfUse.ts';
+import data from './EnergyTimeOfUseData.ts';
+import type { EnergyTimeOfUseArgs } from '../../types/index.ts';
 
 interface TestData {
   name: string;

--- a/src/rateEngine/billingDeterminants/__tests__/EnergyTimeOfUse.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/EnergyTimeOfUse.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import EnergyTimeOfUse from '../EnergyTimeOfUse.ts';
 import data from './EnergyTimeOfUseData.ts';
 import type { EnergyTimeOfUseArgs } from '../../types/index.ts';

--- a/src/rateEngine/billingDeterminants/__tests__/HourlyEnergy.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/HourlyEnergy.test.ts
@@ -1,5 +1,5 @@
-import HourlyEnergy from '../HourlyEnergy';
-import LoadProfile from '../../LoadProfile';
+import HourlyEnergy from '../HourlyEnergy.ts';
+import LoadProfile from '../../LoadProfile.ts';
 
 describe('HourlyEnergy', () => {
   describe('with a February hour', () => {

--- a/src/rateEngine/billingDeterminants/__tests__/MonthlyDemand.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/MonthlyDemand.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import MonthlyDemand from '../MonthlyDemand';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import MonthlyDemand from '../MonthlyDemand.ts';
 
 const getLoadProfileOfOneThroughTen = () => times(8760, num => num % 10 + 1);
 

--- a/src/rateEngine/billingDeterminants/__tests__/MonthlyDemand.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/MonthlyDemand.test.ts
@@ -1,5 +1,5 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import MonthlyDemand from '../MonthlyDemand.ts';
 
 const getLoadProfileOfOneThroughTen = () => times(8760, num => num % 10 + 1);

--- a/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
@@ -1,6 +1,6 @@
-import LoadProfile from '../../LoadProfile';
-import times from 'lodash/times';
-import MonthlyEnergy from '../MonthlyEnergy';
+import LoadProfile from '../../LoadProfile.ts';
+import {times} from 'lodash';
+import MonthlyEnergy from '../MonthlyEnergy.ts';
 import { sum } from 'lodash';
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);

--- a/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/MonthlyEnergy.test.ts
@@ -1,7 +1,7 @@
 import LoadProfile from '../../LoadProfile.ts';
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import MonthlyEnergy from '../MonthlyEnergy.ts';
-import { sum } from 'lodash';
+import { sum } from "lodash-es";
 
 const getLoadProfileOfOnes = () => times(8760, () => 1);
 

--- a/src/rateEngine/types/index.ts
+++ b/src/rateEngine/types/index.ts
@@ -1,9 +1,9 @@
 import { Params as GoalSeekParams } from 'goal-seek';
-import LoadProfile from '../LoadProfile';
-import PriceProfile from '../PriceProfile';
-import RateElement from '../RateElement';
-import BillingDeterminants from '../billingDeterminants/_BillingDeterminants';
-import { BillingCategory, RateElementClassification } from '../constants';
+import LoadProfile from '../LoadProfile.ts';
+import PriceProfile from '../PriceProfile.ts';
+import RateElement from '../RateElement.ts';
+import BillingDeterminants from '../billingDeterminants/_BillingDeterminants.ts';
+import { BillingCategory, RateElementClassification } from '../constants/index.ts';
 
 /**
  * Here's an example rate definition, with the types of the

--- a/src/rateEngine/utils/__tests__/assumptions.test.ts
+++ b/src/rateEngine/utils/__tests__/assumptions.test.ts
@@ -1,4 +1,4 @@
-import { daysPerMonth } from '../assumptions';
+import { daysPerMonth } from '../assumptions.ts';
 
 const leapYearDays = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 const nonLeapYearDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];

--- a/src/rateEngine/utils/assumptions.ts
+++ b/src/rateEngine/utils/assumptions.ts
@@ -1,4 +1,4 @@
-import { isLeapYear, setYearOnDate } from './datetimes';
+import { isLeapYear, setYearOnDate } from './datetimes.ts';
 
 export const daysPerMonth = (year?: number): Array<number> => {
   const _isLeapYear = year === undefined ? false : isLeapYear(setYearOnDate(new Date(), year));

--- a/src/rateEngine/utils/expandedDates.ts
+++ b/src/rateEngine/utils/expandedDates.ts
@@ -1,5 +1,11 @@
-import dayjs from "dayjs/esm";
-import {times} from 'lodash';
+import dayjs from "dayjs";
+// @ts-ignore - no import from dayjs
+import timezone from "dayjs/plugin/timezone";
+dayjs.extend(timezone)
+// @ts-ignore - no import from dayjs
+dayjs.tz.setDefault("America/New_York")
+
+import { times } from 'lodash-es';
 import type { ExpandedDate } from '../types/index.ts';
 import { isLeapYear } from './datetimes.ts';
 

--- a/src/rateEngine/utils/expandedDates.ts
+++ b/src/rateEngine/utils/expandedDates.ts
@@ -1,7 +1,7 @@
-import dayjs from "dayjs";
-import times from 'lodash/times';
-import type { ExpandedDate } from '../types';
-import { isLeapYear } from './datetimes';
+import dayjs from "dayjs/esm";
+import {times} from 'lodash';
+import type { ExpandedDate } from '../types/index.ts';
+import { isLeapYear } from './datetimes.ts';
 
 const dates: Record<number, Array<ExpandedDate>> = {};
 

--- a/src/rateEngine/validators/BlockedTiersValidator.test.ts
+++ b/src/rateEngine/validators/BlockedTiersValidator.test.ts
@@ -1,11 +1,11 @@
-import LoadProfile from '../LoadProfile';
-import BlockedTiersValidator from "./BlockedTiersValidator";
+import LoadProfile from '../LoadProfile.ts';
+import BlockedTiersValidator from './BlockedTiersValidator.ts';
 
 describe('BlockedTiersValidator', () => {
   let loadProfile: LoadProfile;
 
   beforeEach(() => {
-    loadProfile = new LoadProfile(new Array(8760).fill(1), {year: 2018})
+    loadProfile = new LoadProfile(new Array(8760).fill(1), { year: 2018 });
   });
 
   describe('a non filtered blocked tier definition', () => {
@@ -13,7 +13,7 @@ describe('BlockedTiersValidator', () => {
       const blockedTiers = [
         {
           min: new Array(12).fill(0),
-          max: new Array(12).fill(Infinity)
+          max: new Array(12).fill(Infinity),
         },
       ];
 
@@ -29,12 +29,12 @@ describe('BlockedTiersValidator', () => {
         {
           min: new Array(12).fill(0),
           max: new Array(12).fill(Infinity),
-          daysOfWeek: [1,2,3,4,5],
+          daysOfWeek: [1, 2, 3, 4, 5],
         },
         {
           min: new Array(12).fill(0),
           max: new Array(12).fill(Infinity),
-          daysOfWeek: [6,0],
+          daysOfWeek: [6, 0],
         },
       ];
 
@@ -49,7 +49,7 @@ describe('BlockedTiersValidator', () => {
           {
             min: new Array(12).fill(0),
             max: new Array(12).fill(Infinity),
-            daysOfWeek: [1,2,3,4,5],
+            daysOfWeek: [1, 2, 3, 4, 5],
           },
           {
             min: new Array(12).fill(0),
@@ -73,12 +73,12 @@ describe('BlockedTiersValidator', () => {
           {
             min: new Array(12).fill(0),
             max: new Array(12).fill(Infinity),
-            daysOfWeek: [1,2,3,4,5,0],
+            daysOfWeek: [1, 2, 3, 4, 5, 0],
           },
           {
             min: new Array(12).fill(0),
             max: new Array(12).fill(Infinity),
-            daysOfWeek: [6,0],
+            daysOfWeek: [6, 0],
           },
         ];
 
@@ -92,5 +92,5 @@ describe('BlockedTiersValidator', () => {
         expect(validator.allErrors().length).toBe(SUNDAYS_IN_2018 * HOURS_IN_DAY * (MONTHS_IN_YEAR * 2));
       });
     });
-  })
+  });
 });

--- a/src/rateEngine/validators/BlockedTiersValidator.ts
+++ b/src/rateEngine/validators/BlockedTiersValidator.ts
@@ -1,10 +1,10 @@
-import Validator from './_Validator';
-import times from 'lodash/times';
-import expandedDates from '../utils/expandedDates';
-import LoadProfileFilter from '../LoadProfileFilter';
-import LoadProfile from '../LoadProfile';
-import type { MinMaxPair, BlockedTiersArgs } from '../types';
-import convertInfinities from '../utils/convertInfinities';
+import {times} from 'lodash';
+import Validator from './_Validator.ts';
+import expandedDates from '../utils/expandedDates.ts';
+import LoadProfileFilter from '../LoadProfileFilter.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { MinMaxPair, BlockedTiersArgs } from '../types/index.ts';
+import convertInfinities from '../utils/convertInfinities.ts';
 
 class BlockedTiersValidator extends Validator {
   private _args: Array<BlockedTiersArgs>;

--- a/src/rateEngine/validators/BlockedTiersValidator.ts
+++ b/src/rateEngine/validators/BlockedTiersValidator.ts
@@ -1,4 +1,4 @@
-import {times} from 'lodash';
+import {times} from "lodash-es";
 import Validator from './_Validator.ts';
 import expandedDates from '../utils/expandedDates.ts';
 import LoadProfileFilter from '../LoadProfileFilter.ts';

--- a/src/rateEngine/validators/EnergyTimeOfUseValidator.ts
+++ b/src/rateEngine/validators/EnergyTimeOfUseValidator.ts
@@ -1,8 +1,8 @@
-import Validator from './_Validator';
-import expandedDates from '../utils/expandedDates';
-import LoadProfileFilter from '../LoadProfileFilter';
-import LoadProfile from '../LoadProfile';
-import type { RateComponentInterface, EnergyTimeOfUseArgs } from '../types';
+import Validator from './_Validator.ts';
+import expandedDates from '../utils/expandedDates.ts';
+import LoadProfileFilter from '../LoadProfileFilter.ts';
+import LoadProfile from '../LoadProfile.ts';
+import type { RateComponentInterface, EnergyTimeOfUseArgs } from '../types/index.ts';
 
 class EnergyTimeOfUseValidator extends Validator {
   private _args: Array<RateComponentInterface & EnergyTimeOfUseArgs>;

--- a/src/rateEngine/validators/GenericValidator.ts
+++ b/src/rateEngine/validators/GenericValidator.ts
@@ -1,4 +1,4 @@
-import Validator from './_Validator';
+import Validator from './_Validator.ts';
 
 class GenericValidator extends Validator {
   validate() {

--- a/src/rateEngine/validators/_Validator.ts
+++ b/src/rateEngine/validators/_Validator.ts
@@ -1,4 +1,4 @@
-import { ValidatorError, LabeledError } from '../types';
+import { ValidatorError, LabeledError } from '../types/index.ts';
 
 abstract class Validator {
   protected _errors: Array<LabeledError> = [];

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,10 @@
     // npm run analyze
     "sourceMap": false,
 
-    "removeComments": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
 
     "declaration": true,
     "emitDeclarationOnly": false

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,12 +7,6 @@
     // npm run analyze
     "sourceMap": false,
 
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
-
-    "declaration": true,
     "emitDeclarationOnly": false
   },
   "include": ["src"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,8 +5,13 @@
 
     // switch to true to use with source-map-explorer
     // npm run analyze
-    "sourceMap": false
+    "sourceMap": false,
+
+    "removeComments": true,
+
+    "declaration": true,
+    "emitDeclarationOnly": false
   },
   "include": ["src"],
-  "exclude": ["node_modules", "src/rateEngine/**/__mocks__", "src/rateEngine/**/__tests__"]
+  "exclude": ["node_modules", "src/rateEngine/**/__mocks__", "src/rateEngine/**/__tests__", "**/**/*.test.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,14 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "ES6",
-
-    // switch to true to use with source-map-explorer
-    // npm run analyze
-    "sourceMap": false,
-
-    "emitDeclarationOnly": false
-  },
-  "include": ["src"],
   "exclude": ["node_modules", "src/rateEngine/**/__mocks__", "src/rateEngine/**/__tests__", "**/**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
-    "target": "ES6",
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
-    "outDir": "./lib",
-    
     /* Module Resolution */
+    "target": "ES6",
+    "module": "NodeNext", // ES Modules
+    "moduleResolution": "nodenext", // ES Modules
+    
+    /* Polyfill up-to */
+    "lib": ["es2019"],
+    
+    "outDir": "./lib",
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,12 @@
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "outDir": "./lib",
+    
+    /* Module Resolution */
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "declaration": true,
+    "emitDeclarationOnly": false,
     "resolveJsonModule": true,
     "esModuleInterop": true,
 
@@ -13,9 +18,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noEmit": true,
-    "allowImportingTsExtensions": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "module": "commonjs",
-    "declaration": true,
-    "lib": ["es2019"],
+    "lib": ["ESNext"],
+    "target": "ES6",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "outDir": "./lib",
+    "declaration": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
 
@@ -13,6 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
* Rebased to remove changes from https://github.com/dcordz/electric-rate-engine/tree/sorting-formatting-rates
* Target ES modules in tsconfig.
* Add rollup to build both ES modules and commonjs.
* Update package.json to `"type": "module"`, point "main" to commonjs build file and "module" to ES modules build file from rollup.
* Append to `.ts` to all import file suffixes in order to support ES modules.
* Convert jest config and tests to support ES modules.
* Replace `lodash` with [lodash-es](https://www.npmjs.com/package/lodash-es) in order to support ES modules.
* Export RateComponent and RateElement from src/index.ts