### PR TITLE
Let's get CI/CD green

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
   tsc:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         version: [14, 16, 18, 20, 22]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,12 @@ jobs:
           cache: "npm"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: |
+          if [ "${{ matrix.version }}" == "14" ]; then
+            npm install
+          else
+            npm ci
+          fi
 
       - name: Build the project
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,8 @@ jobs:
             npm ci
           fi
 
+      - name: Typecheck the project
+        run: npm run tsc
+
       - name: Build the project
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
   tsc:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: [12, 14, 16, 18, 20, 22]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,7 @@ jobs:
           cache: "npm"
 
       - name: Install JS dependencies
-        run: |
-          if [ "${{ matrix.version }}" == "14" ]; then
-            npm install
-          else
-            npm ci
-          fi
+        run: npm install
 
       - name: Typecheck the project
         run: npm run tsc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [12, 14, 16, 18, 20, 22]
+        version: [14, 16, 18, 20, 22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -21,7 +21,12 @@ jobs:
           cache: "npm"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: |
+          if [ "${{ matrix.version }}" == "14" ]; then
+            npm install
+          else
+            npm ci
+          fi
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -21,12 +21,7 @@ jobs:
           cache: "npm"
 
       - name: Install JS dependencies
-        run: |
-          if [ "${{ matrix.version }}" == "14" ]; then
-            npm install
-          else
-            npm ci
-          fi
+        run: npm install
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: [12, 14, 16, 18, 20, 22]
     steps:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         version: [14, 16, 18, 20, 22]
     steps:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [12, 14, 16, 18, 20, 22]
+        version: [14, 16, 18, 20, 22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/bellawatt/electric-rate-engine
 COPY --chown=bellawatt package.json ./
 COPY --chown=bellawatt package-lock.json ./
 
-RUN npm ci
+RUN npm install
 
 COPY ./ ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/bellawatt/electric-rate-engine
 COPY --chown=bellawatt package.json ./
 COPY --chown=bellawatt package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY ./ ./
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "analyze": "source-map-explorer 'lib/**/*.js' --no-border-checks",
-    "lint": "npx eslint -c eslint.config.js src"
+    "lint": "npx eslint -c eslint.config.js src",
+    "tsc": "tsc -p tsconfig.json"
   },
   "keywords": [],
   "author": "",

--- a/src/rateEngine/__mocks__/rates/e-tou-a.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-a.ts
@@ -1,6 +1,6 @@
 import { times } from "lodash";
 import type { RateInterface } from '../../types/index';
-import { RateElementTypeEnum } from "../../constants/index.ts";
+import { RateElementTypeEnum } from "../../constants/index";
 
 const HOLIDAYS = [
   '2018-01-01',

--- a/src/rateEngine/__mocks__/rates/e-tou-c.ts
+++ b/src/rateEngine/__mocks__/rates/e-tou-c.ts
@@ -1,6 +1,6 @@
 import { times } from "lodash";
 import type { RateInterface } from '../../types/index';
-import { RateElementTypeEnum } from "../../constants/index.ts";
+import { RateElementTypeEnum } from "../../constants/index";
 
 const summerPeakCharge = 0.41333;
 const summmerOffpeakCharge = 0.34989;


### PR DESCRIPTION
As we suspected, merging in #38 greeted us with some failing workflows. This PR gets everything running green. Changes included are:

* Drop Node 12 support. The version of Jest we have uses optional chaining that Node 12 doesn't support, so we'd have to either polyfill it or downgrade Jest. I don't like either option. It's well past EOL, and we just released a major version. I'm satisfied to leave it behind.
* ~~Node 14 gets to hang around. It cannot install the dependencies as strictly generated by Node 22 via `npm ci`. But it can install them if we use the looser `npm install`. You could argue that it'd be better to let versions float a bit since people installing the~~ [update: as I typed out "you could argue that..." i actually argued this in my head and decided that `npm install` is better than `npm ci` for a package.]
* Run the plain old `tsc` command in the build action. The excluded files in `tsconfig.build.json` had some typescript errors. This will catch them in the future.