### PR TITLE
Demand per day averaged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        version: [14, 16, 18, 20, 22]
+        version: [16, 18, 20, 22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        version: [14, 16, 18, 20, 22]
+        version: [16, 18, 20, 22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Electric Rate Engine",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
   "license": "MIT",
   "repository": "git://github.com/bellawatt/electric-rate-engine.git",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Electric Rate Engine",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "license": "MIT",
   "repository": "git://github.com/bellawatt/electric-rate-engine.git",
   "scripts": {

--- a/src/rateEngine/BillingDeterminantsFactory.ts
+++ b/src/rateEngine/BillingDeterminantsFactory.ts
@@ -2,6 +2,7 @@ import AnnualDemand from './billingDeterminants/AnnualDemand';
 import BlockedTiersInDays from './billingDeterminants/BlockedTiersInDays';
 import BlockedTiersInMonths from './billingDeterminants/BlockedTiersInMonths';
 import DemandPerDay from './billingDeterminants/DemandPerDay';
+import DemandPerDayAveraged from './billingDeterminants/DemandPerDayAveraged';
 import DemandTiersInMonths from './billingDeterminants/DemandTiersInMonths';
 import DemandTimeOfUse from './billingDeterminants/DemandTimeOfUse';
 import EnergyTimeOfUse from './billingDeterminants/EnergyTimeOfUse';
@@ -49,6 +50,8 @@ class BillingDeterminantsFactory {
         return rateComponents.map(({ charge, name, ...args }) => ({ charge, name, billingDeterminants: new DemandTimeOfUse(args, loadProfile) }));
       case 'DemandPerDay':
         return rateComponents.map(({ charge, name, ...args }) => ({ charge, name, billingDeterminants: new DemandPerDay(args, loadProfile) }));
+      case 'DemandPerDayAveraged':
+        return rateComponents.map(({ charge, name, ...args }) => ({ charge, name, billingDeterminants: new DemandPerDayAveraged(args, loadProfile) }));
       default:
         throw new Error(`Unknown rateElementType: ${rateElementType}`);
     }

--- a/src/rateEngine/billingDeterminants/DemandPerDayAveraged.ts
+++ b/src/rateEngine/billingDeterminants/DemandPerDayAveraged.ts
@@ -1,0 +1,54 @@
+import LoadProfile from '../LoadProfile';
+import BillingDeterminants from './_BillingDeterminants';
+import times from 'lodash/times';
+import groupBy from 'lodash/groupBy';
+import mean from 'lodash/mean';
+import { RateElementClassification, BillingDeterminantsUnits } from '../constants';
+import type { DemandPerDayAveragedArgs, LoadProfileFilterArgs } from '../types';
+
+// This billing determinant calculates the average of the top n daily maximum loads for each month.
+// It is used (for now) only for ConEd's SC1 Rate IV.
+
+class DemandPerDayAveraged extends BillingDeterminants {
+  private _filters: LoadProfileFilterArgs;
+  private _numLoadsToAverage: number;
+  private _loadProfile: LoadProfile;
+
+  rateElementType = 'Demand Per Day';
+  rateElementClassification = RateElementClassification.DEMAND;
+  units = BillingDeterminantsUnits.KW;
+
+  constructor({ numLoadsToAverage, ...filters }: DemandPerDayAveragedArgs, loadProfile: LoadProfile) {
+    super();
+
+    this._filters = filters;
+    this._numLoadsToAverage = numLoadsToAverage;
+    this._loadProfile = loadProfile;
+  }
+
+  filteredLoadProfile(): LoadProfile {
+    return this._loadProfile.filterBy(this._filters);
+  }
+
+  calculate(): Array<number> {
+    const months = times(12, (i) => i);
+    const expanded = this.filteredLoadProfile().expanded();
+
+    return months.map((m) => {
+      const monthLoads = expanded.filter(({ month }) => m === month);
+
+      // chunk monthly loads by day (31-element array for January, etc.)
+      const dayLoads = Object.values(groupBy(monthLoads, (val) => val.date));
+
+      // get the maximum load for each day
+      const maxByDay = dayLoads.map((day) => Math.max(...day.map(({ load }) => load)));
+
+      // take the top n max daily loads and average them
+      const sorted = [...maxByDay].sort((a, b) => b - a);
+      const loadsToAverage = sorted.slice(0, this._numLoadsToAverage);
+      return mean(loadsToAverage);
+    });
+  }
+}
+
+export default DemandPerDayAveraged;

--- a/src/rateEngine/billingDeterminants/__tests__/DemandPerDayAveraged.test.ts
+++ b/src/rateEngine/billingDeterminants/__tests__/DemandPerDayAveraged.test.ts
@@ -1,0 +1,134 @@
+import LoadProfile from '../../LoadProfile';
+import times from 'lodash/times';
+import DemandPerDayAveraged from '../DemandPerDayAveraged';
+
+const getLoadProfileOfOnes = () => times(8760, () => 1);
+
+const zerosByMonth = times(12, () => 0);
+
+describe('DemandPerDayAveraged', () => {
+  let loadProfile: LoadProfile;
+
+  beforeEach(() => {
+    loadProfile = new LoadProfile(getLoadProfileOfOnes(), { year: 2019 });
+  });
+
+  describe('calculate', () => {
+    it('calculates demand per day averaged on a simple load profile with nothing filtered', () => {
+      const result = new DemandPerDayAveraged(
+        {
+          numLoadsToAverage: 3,
+          months: [],
+          daysOfWeek: [],
+          hourStarts: [],
+          onlyOnDays: [],
+          exceptForDays: [],
+        },
+        loadProfile,
+      ).calculate();
+
+      result.forEach((val) => {
+        expect(val).toBeCloseTo(1);
+      });
+    });
+
+    it('calculates demand per day averaged on a simple load profile with everything filtered', () => {
+      const result = new DemandPerDayAveraged(
+        {
+          numLoadsToAverage: 3,
+          months: [],
+          daysOfWeek: [],
+          hourStarts: [],
+          onlyOnDays: ['2015-01-01'],
+          exceptForDays: [],
+        },
+        loadProfile,
+      ).calculate();
+
+      result.forEach((val, i) => {
+        expect(val).toBeCloseTo(zerosByMonth[i]);
+      });
+    });
+
+    it('calculates demand per day with actual values', () => {
+      const loads = getLoadProfileOfOnes();
+      // jan 1
+      loads[13] = 15;
+      loads[14] = 20;
+      // jan 2
+      loads[37] = 13;
+      // jan 3
+      loads[61] = 12;
+      // jan 4
+      loads[85] = 11;
+
+      // mar 1
+      loads[1416] = 8;
+      // mar 2
+      loads[1440] = 7;
+      loads[1441] = 9;
+      // mar 3
+      loads[1464] = 6;
+
+      const result = new DemandPerDayAveraged(
+        {
+          numLoadsToAverage: 3,
+          months: [],
+          daysOfWeek: [],
+          hourStarts: [],
+          onlyOnDays: [],
+          exceptForDays: [],
+        },
+        new LoadProfile(loads, { year: 2019 }),
+      ).calculate();
+
+      const expected = [15, 1, 7.6667, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      result.forEach((val, i) => {
+        expect(val).toBeCloseTo(expected[i]);
+      });
+    });
+
+    it('calculates demand per day with actual values, 4 loads averaged, and filters applied', () => {
+      const loads = getLoadProfileOfOnes();
+      // jan 1 (filtered out)
+      loads[13] = 15;
+      loads[14] = 20;
+      // jan 2 (filtered out)
+      loads[37] = 13;
+      // jan 3 (filtered out)
+      loads[61] = 12;
+      // jan 4 (filtered out)
+      loads[85] = 11;
+
+      // mar 1 - hour 0 (filtered out)
+      loads[1416] = 8;
+      // mar 2
+      loads[1441] = 7;
+      loads[1442] = 9;
+      // mar 3
+      loads[1465] = 6;
+      // mar 4
+      loads[1490] = 5;
+      loads[1492] = 4;
+      // mar 5
+      loads[1520] = 3;
+
+      const result = new DemandPerDayAveraged(
+        {
+          numLoadsToAverage: 4,
+          months: [2, 3, 4],
+          daysOfWeek: [],
+          hourStarts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+          onlyOnDays: [],
+          exceptForDays: [],
+        },
+        new LoadProfile(loads, { year: 2019 }),
+      ).calculate();
+
+      const expected = [0, 0, 5.75, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+      result.forEach((val, i) => {
+        expect(val).toBeCloseTo(expected[i]);
+      });
+    });
+  });
+});

--- a/src/rateEngine/types/index.ts
+++ b/src/rateEngine/types/index.ts
@@ -68,6 +68,7 @@ type BaseRateElementType =
     | BlockedTiersInDaysRateElementInterface
     | BlockedTiersInMonthsRateElementInterface
     | DemandPerDayRateElementInterface
+    | DemandPerDayAveragedRateElementInterface
     | DemandTiersInMonthsRateElementInterface
     | DemandTimeOfUseRateElementInterface
     | EnergyTimeOfUseRateElementInterface
@@ -162,6 +163,11 @@ export interface DemandPerDayRateElementInterface extends BaseRateElementInterfa
   rateComponents: Array<BaseRateComponentInterface & DemandPerDayArgs>;
 };
 
+export interface DemandPerDayAveragedRateElementInterface extends BaseRateElementInterface {
+  rateElementType: 'DemandPerDayAveraged';
+  rateComponents: Array<BaseRateComponentInterface & DemandPerDayAveragedArgs>;
+};
+
 
 export interface RateComponentArgs {
   charge: number | Array<number>;
@@ -203,6 +209,10 @@ export interface LoadProfileOptions {
 export interface BlockedTiersArgs extends LoadProfileFilterArgs {
   min: Array<number | 'Infinity'>;
   max: Array<number | 'Infinity'>;
+}
+
+export interface DemandPerDayAveragedArgs extends LoadProfileFilterArgs {
+  numLoadsToAverage: number;
 }
 
 export type DemandPerDayArgs = LoadProfileFilterArgs;


### PR DESCRIPTION
Adds a BillingDeterminant `DemandPerDayAveraged` which takes a number `n` and calculates the average of the top `n` _daily maximum_ loads for each month – I can't imagine this will be used for much else besides ConEd's demand-based rate.

Also removes Node v14 from the test suite in order to fix `ts-jest` errors, though there is discussion on Twist of potential downstream effects.